### PR TITLE
feat: fleet exec コマンドを追加

### DIFF
--- a/crates/fleetflow/tests/cli_test.rs
+++ b/crates/fleetflow/tests/cli_test.rs
@@ -121,3 +121,16 @@ fn test_deploy_conflict_positional_and_flag() {
         .failure()
         .stderr(predicate::str::contains("cannot be used with"));
 }
+
+/// execコマンドのヘルプが正しく表示されることを確認
+#[test]
+fn test_exec_help() {
+    let mut cmd = Command::cargo_bin("fleet").unwrap();
+    cmd.arg("exec")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[STAGE]"))
+        .stdout(predicate::str::contains("--service"))
+        .stdout(predicate::str::contains("[COMMAND]"));
+}


### PR DESCRIPTION
## Summary

- `fleet exec` コマンドを新規追加。サービスコンテナ内でコマンドを実行可能に
- FleetFlowの命名規則（`{project}-{stage}-{service}`）を活用し、長いコンテナ名の手動組み立てが不要に
- コマンド省略時は `/bin/sh` でインタラクティブシェルに入る

### 使用例

```bash
fleet exec prod -n surrealdb -- surreal sql --endpoint http://localhost:8000
fleet exec prod -n surrealdb          # → /bin/sh
fleet exec prod -n caddy -- caddy reload
FLEET_STAGE=prod fleet exec -n creo-app-server -- ls /app
```

## Test plan

- [x] `cargo build` — ビルド成功
- [x] `cargo test` — 全テスト通過（CLIテスト11件 + 全体156件）
- [x] `fleet exec --help` — ヘルプ表示正常
- [ ] 本番環境で `fleet exec prod -n surrealdb -- surreal sql ...` を実行して動作確認

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)