### PR TITLE
feat: fleet deploy 後にDockerクリーンアップを自動実行

### DIFF
--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -180,6 +180,9 @@ enum Commands {
         /// イメージのpullをスキップ（デフォルトは常にpull）
         #[arg(long)]
         no_pull: bool,
+        /// デプロイ後の不要イメージ・ビルドキャッシュ削除をスキップ
+        #[arg(long)]
+        no_prune: bool,
         /// 確認なしで実行
         #[arg(short, long)]
         yes: bool,
@@ -505,10 +508,20 @@ async fn main() -> anyhow::Result<()> {
             stage_flag,
             service,
             no_pull,
+            no_prune,
             yes,
         } => {
             let stage = stage.or(stage_flag);
-            commands::deploy::handle(&config, &project_root, stage, service, no_pull, yes).await?;
+            commands::deploy::handle(
+                &config,
+                &project_root,
+                stage,
+                service,
+                no_pull,
+                no_prune,
+                yes,
+            )
+            .await?;
         }
         Commands::Validate {
             stage: _,


### PR DESCRIPTION
## Summary
- `fleet deploy` 完了後にStep 5として不要イメージ・ビルドキャッシュを自動削除
- 1週間(168h)以上古い未使用イメージ + ビルドキャッシュを対象
- volumeは安全のため対象外
- `--no-prune` オプションでスキップ可能

## 期待する動作
```
✓ コンテナ停止・削除
✓ 最新イメージをpull
✓ ネットワーク準備
✓ コンテナ作成・起動
✓ 不要イメージを削除 (3 個, 245.8MB 解放)    ← 新規
✓ ビルドキャッシュを削除 (128.5MB 解放)       ← 新規
```

## Test plan
- [x] `cargo build` — ビルド成功
- [x] `cargo test` — 全テスト通過
- [x] `cargo clippy` — 警告なし
- [x] `cargo fmt -- --check` — フォーマットクリーン
- [x] `fleet deploy --help` — `--no-prune` オプション表示確認

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)