### PR TITLE
feat: fleet registry deploy でSSHリモートデプロイを実行

### DIFF
--- a/crates/fleetflow-core/src/model/cloud.rs
+++ b/crates/fleetflow-core/src/model/cloud.rs
@@ -58,6 +58,13 @@ pub struct ServerResource {
     /// 例: "/opt/myapp" - CI/CDやmiseタスクでデプロイ先を参照
     pub deploy_path: Option<String>,
 
+    /// SSH接続先（IPアドレスまたはホスト名）
+    /// 例: "153.xxx.xxx.xxx" - fleet registry deploy でSSH経由のリモートデプロイに使用
+    pub ssh_host: Option<String>,
+
+    /// SSHユーザー名（デフォルト: "root"）
+    pub ssh_user: Option<String>,
+
     /// 追加設定
     pub config: HashMap<String, String>,
 }

--- a/crates/fleetflow-registry/src/parser.rs
+++ b/crates/fleetflow-registry/src/parser.rs
@@ -269,6 +269,36 @@ deployment {
     }
 
     #[test]
+    fn test_parse_registry_with_ssh_info() {
+        let kdl = r#"
+registry "test-fleet"
+
+fleet "creo" {
+    path "fleets/creo"
+    description "Creo Memories"
+}
+
+server "vps-01" {
+    provider "sakura-cloud"
+    plan "4core-8gb"
+    ssh-key "deployment"
+    ssh-host "153.120.168.42"
+    ssh-user "root"
+    deploy-path "/opt/apps"
+}
+
+deployment {
+    route fleet="creo" stage="live" server="vps-01"
+}
+"#;
+        let registry = parse_registry(kdl).unwrap();
+        let vps = registry.servers.get("vps-01").unwrap();
+        assert_eq!(vps.ssh_host.as_deref(), Some("153.120.168.42"));
+        assert_eq!(vps.ssh_user.as_deref(), Some("root"));
+        assert_eq!(vps.deploy_path.as_deref(), Some("/opt/apps"));
+    }
+
+    #[test]
     fn test_parse_registry_no_routes() {
         let kdl = r#"
 registry "test"


### PR DESCRIPTION
## 概要

`fleet registry deploy <fleet> --yes` でSSH経由のリモートデプロイを実行可能にする Phase 2 実装。

## 変更内容

- **ServerResource 拡張**: `ssh_host` / `ssh_user` フィールドを追加
- **パーサー**: `ssh-host` / `ssh-user` のパース対応（kebab-case / snake_case 両対応）
- **deploy ハンドラ**: 情報表示のみ → SSH 実行に書き換え
  - `--yes` なし: デプロイ計画表示のみ（dry-run）
  - `--yes` あり: SSH 経由で `fleet deploy -s <stage> --yes` を実行
- **ドキュメント**: spec/design に Phase 2 SSH デプロイ仕様を追記

## 実行例

```bash
# 計画表示のみ
fleet registry deploy creo

# SSH経由でデプロイ実行
fleet registry deploy creo --yes
```

## テスト

- `cargo test --workspace` 全テスト通過
- `cargo clippy --workspace` 警告なし
- 新規テスト 3件追加（パーサー 2件 + Registry 1件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)