### PR TITLE
fix: fleet deploy -n で複数サービスの同時指定に対応

### DIFF
--- a/crates/fleetflow/src/commands/deploy.rs
+++ b/crates/fleetflow/src/commands/deploy.rs
@@ -6,7 +6,7 @@ pub async fn handle(
     config: &fleetflow_core::Flow,
     project_root: &std::path::Path,
     stage: Option<String>,
-    service: Option<String>,
+    services: Vec<String>,
     no_pull: bool,
     no_prune: bool,
     yes: bool,
@@ -24,24 +24,26 @@ pub async fn handle(
         .get(&stage_name)
         .ok_or_else(|| anyhow::anyhow!("ステージ '{}' が見つかりません", stage_name))?;
 
-    // デプロイ対象のサービスを決定（--serviceオプションがあればフィルタ）
-    let target_services: Vec<String> = if let Some(ref target) = service {
+    // デプロイ対象のサービスを決定（-n オプションがあればフィルタ）
+    let target_services: Vec<String> = if !services.is_empty() {
         // 指定されたサービスがステージに存在するか確認
-        if !stage_config.services.contains(target) {
-            return Err(anyhow::anyhow!(
-                "サービス '{}' はステージ '{}' に存在しません。\n利用可能なサービス: {}",
-                target,
-                stage_name,
-                stage_config.services.join(", ")
-            ));
+        for target in &services {
+            if !stage_config.services.contains(target) {
+                return Err(anyhow::anyhow!(
+                    "サービス '{}' はステージ '{}' に存在しません。\n利用可能なサービス: {}",
+                    target,
+                    stage_name,
+                    stage_config.services.join(", ")
+                ));
+            }
         }
-        vec![target.clone()]
+        services
     } else {
         stage_config.services.clone()
     };
 
     println!();
-    if service.is_some() {
+    if !target_services.is_empty() && target_services.len() < stage_config.services.len() {
         println!(
             "{}",
             format!("デプロイ対象サービス (指定: {} 個):", target_services.len()).bold()

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -174,9 +174,9 @@ enum Commands {
             hide = true
         )]
         stage_flag: Option<String>,
-        /// デプロイ対象のサービス（省略時は全サービス）
+        /// デプロイ対象のサービス（複数指定可: -n svc1 -n svc2）
         #[arg(short = 'n', long)]
-        service: Option<String>,
+        service: Vec<String>,
         /// イメージのpullをスキップ（デフォルトは常にpull）
         #[arg(long)]
         no_pull: bool,


### PR DESCRIPTION
## Summary
- `fleet deploy` の `-n` フラグで複数サービスを同時に指定可能にした
- `-n svc1 -n svc2` の形式で複数指定ができる

## Changes
- `main.rs`: `-n` の型を `Option<String>` → `Vec<String>` に変更
- `deploy.rs`: フィルタロジックを `Vec` に対応

## Test plan
- [x] `cargo check` 通過
- [x] `cargo test` 全187テスト通過
- [ ] `fleet deploy dev -n creo-app-server -n creo-mcp-server --yes` で2サービス同時デプロイ

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)