### PR TITLE
feat: deploy/build の -n オプションで複数サービスを同時指定できるようにした

### DIFF
--- a/crates/fleetflow/src/build.rs
+++ b/crates/fleetflow/src/build.rs
@@ -74,7 +74,7 @@ pub async fn handle_build_command(
     project_root: &std::path::Path,
     config: &fleetflow_core::Flow,
     stage_name: &str,
-    service_filter: Option<&str>,
+    service_filters: &[String],
     push: bool,
     cli_tag: Option<&str>,
     registry: Option<&str>,
@@ -109,23 +109,25 @@ pub async fn handle_build_command(
     }
 
     // ビルド対象のサービスを決定
-    let target_services: Vec<&String> = if let Some(filter) = service_filter {
-        // 特定のサービスのみ
-        if !stage_config.services.contains(&filter.to_string()) {
-            return Err(anyhow::anyhow!(
-                "サービス '{}' はステージ '{}' に含まれていません",
-                filter,
-                stage_name
-            ));
+    let target_services: Vec<&String> = if service_filters.is_empty() {
+        // 全サービス
+        stage_config.services.iter().collect()
+    } else {
+        // 指定されたサービスのみ
+        for filter in service_filters {
+            if !stage_config.services.contains(filter) {
+                return Err(anyhow::anyhow!(
+                    "サービス '{}' はステージ '{}' に含まれていません",
+                    filter,
+                    stage_name
+                ));
+            }
         }
         stage_config
             .services
             .iter()
-            .filter(|s| *s == filter)
+            .filter(|s| service_filters.contains(s))
             .collect()
-    } else {
-        // 全サービス
-        stage_config.services.iter().collect()
     };
 
     // ビルド可能なサービスをフィルタ（build設定があるもののみ）

--- a/crates/fleetflow/src/commands/deploy.rs
+++ b/crates/fleetflow/src/commands/deploy.rs
@@ -6,7 +6,7 @@ pub async fn handle(
     config: &fleetflow_core::Flow,
     project_root: &std::path::Path,
     stage: Option<String>,
-    service: Option<String>,
+    services: &[String],
     no_pull: bool,
     no_prune: bool,
     yes: bool,
@@ -25,23 +25,25 @@ pub async fn handle(
         .ok_or_else(|| anyhow::anyhow!("ステージ '{}' が見つかりません", stage_name))?;
 
     // デプロイ対象のサービスを決定（--serviceオプションがあればフィルタ）
-    let target_services: Vec<String> = if let Some(ref target) = service {
-        // 指定されたサービスがステージに存在するか確認
-        if !stage_config.services.contains(target) {
-            return Err(anyhow::anyhow!(
-                "サービス '{}' はステージ '{}' に存在しません。\n利用可能なサービス: {}",
-                target,
-                stage_name,
-                stage_config.services.join(", ")
-            ));
-        }
-        vec![target.clone()]
-    } else {
+    let target_services: Vec<String> = if services.is_empty() {
         stage_config.services.clone()
+    } else {
+        // 指定されたサービスがステージに存在するか確認
+        for target in services {
+            if !stage_config.services.contains(target) {
+                return Err(anyhow::anyhow!(
+                    "サービス '{}' はステージ '{}' に存在しません。\n利用可能なサービス: {}",
+                    target,
+                    stage_name,
+                    stage_config.services.join(", ")
+                ));
+            }
+        }
+        services.to_vec()
     };
 
     println!();
-    if service.is_some() {
+    if !services.is_empty() {
         println!(
             "{}",
             format!("デプロイ対象サービス (指定: {} 個):", target_services.len()).bold()

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -174,9 +174,9 @@ enum Commands {
             hide = true
         )]
         stage_flag: Option<String>,
-        /// デプロイ対象のサービス（省略時は全サービス）
+        /// デプロイ対象のサービス（複数指定可、省略時は全サービス）
         #[arg(short = 'n', long)]
-        service: Option<String>,
+        service: Vec<String>,
         /// イメージのpullをスキップ（デフォルトは常にpull）
         #[arg(long)]
         no_pull: bool,
@@ -200,9 +200,9 @@ enum Commands {
             hide = true
         )]
         stage_flag: Option<String>,
-        /// ビルド対象のサービス（省略時は全サービス）
+        /// ビルド対象のサービス（複数指定可、省略時は全サービス）
         #[arg(short = 'n', long)]
-        service: Option<String>,
+        service: Vec<String>,
         /// ビルド後にレジストリにプッシュ
         #[arg(long)]
         push: bool,
@@ -558,7 +558,7 @@ async fn main() -> anyhow::Result<()> {
                 &config,
                 &project_root,
                 stage,
-                service,
+                &service,
                 no_pull,
                 no_prune,
                 yes,
@@ -587,7 +587,7 @@ async fn main() -> anyhow::Result<()> {
                 &project_root,
                 &config,
                 &stage_name,
-                service.as_deref(),
+                &service,
                 push,
                 tag.as_deref(),
                 registry.as_deref(),


### PR DESCRIPTION
## Summary

- `fleet deploy -n` および `fleet build -n` のサービスフィルタを `Option<String>` から `Vec<String>` に変更
- `-n web -n api` のように複数の `-n` フラグを繰り返すことで複数サービスを同時指定できるようになった
- 存在しないサービス名を指定した場合のバリデーションも複数サービスに対応

## 変更ファイル

- `crates/fleetflow/src/main.rs` — `deploy` / `build` の `-n` 引数を `Vec<String>` に変更
- `crates/fleetflow/src/commands/deploy.rs` — `handle()` のシグネチャを `&[String]` に、フィルタロジックを複数対応
- `crates/fleetflow/src/build.rs` — `handle_build_command()` のシグネチャを `&[String]` に、フィルタロジックを複数対応

## Test plan

- [ ] `fleet deploy local -n web` — 単一サービス指定が従来通り動作すること
- [ ] `fleet deploy local -n web -n api` — 複数サービスの同時デプロイが動作すること
- [ ] `fleet build local -n web -n api` — 複数サービスの同時ビルドが動作すること
- [ ] 存在しないサービス名を指定したときにエラーメッセージが表示されること
- [ ] `-n` 省略時に全サービスがデプロイ/ビルドされること

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)