### PR TITLE
feat: Fleet Agent Phase 2 — ヘルスモニタリング（コンテナ監視 + アラート送信）

### DIFF
--- a/crates/fleet-agent/Cargo.toml
+++ b/crates/fleet-agent/Cargo.toml
@@ -34,6 +34,9 @@ serde_json.workspace = true
 unison.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
+# Docker API
+bollard.workspace = true
+
 # CLI
 clap.workspace = true
 

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -11,12 +11,15 @@ use unison::network::client::ProtocolClient;
 
 use crate::deploy;
 use crate::heartbeat;
+use crate::monitor;
 
 pub struct AgentConfig {
     pub cp_endpoint: String,
     pub server_slug: String,
     pub heartbeat_interval_secs: u64,
     pub deploy_base: String,
+    pub monitor_interval_secs: u64,
+    pub restart_threshold: u32,
 }
 
 /// Agent メインループ
@@ -59,10 +62,23 @@ async fn run_session(config: &AgentConfig) -> Result<()> {
         heartbeat::run_loop(&hb_client, &hb_slug, hb_interval).await;
     });
 
+    // モニタータスク起動
+    let mon_client = Arc::clone(&client);
+    let mon_slug = config.server_slug.clone();
+    let mon_config = monitor::MonitorConfig {
+        interval_secs: config.monitor_interval_secs,
+        restart_threshold: config.restart_threshold,
+        alert_cooldown_secs: 300,
+    };
+    let mon_handle = tokio::spawn(async move {
+        monitor::run_loop(&mon_client, &mon_slug, &mon_config).await;
+    });
+
     // コマンド受信ループ
     let result = command_loop(&client, &config.server_slug, &config.deploy_base).await;
 
     hb_handle.abort();
+    mon_handle.abort();
     result
 }
 

--- a/crates/fleet-agent/src/lib.rs
+++ b/crates/fleet-agent/src/lib.rs
@@ -3,3 +3,4 @@
 pub mod agent;
 pub mod deploy;
 pub mod heartbeat;
+pub mod monitor;

--- a/crates/fleet-agent/src/main.rs
+++ b/crates/fleet-agent/src/main.rs
@@ -26,6 +26,14 @@ struct Cli {
     /// デプロイ許可ベースディレクトリ
     #[arg(long, env = "FLEET_AGENT_DEPLOY_BASE", default_value = "/opt/apps")]
     deploy_base: String,
+
+    /// モニター間隔（秒）
+    #[arg(long, env = "FLEET_AGENT_MONITOR_INTERVAL", default_value = "30")]
+    monitor_interval: u64,
+
+    /// リスタート閾値（この回数を超えたらアラート）
+    #[arg(long, env = "FLEET_AGENT_RESTART_THRESHOLD", default_value = "3")]
+    restart_threshold: u32,
 }
 
 #[tokio::main]
@@ -51,6 +59,8 @@ async fn main() -> Result<()> {
         server_slug: cli.server_slug,
         heartbeat_interval_secs: cli.heartbeat_interval,
         deploy_base: cli.deploy_base,
+        monitor_interval_secs: cli.monitor_interval,
+        restart_threshold: cli.restart_threshold,
     })
     .await
 }

--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -84,11 +84,7 @@ impl Severity {
 type CooldownKey = (String, String);
 
 /// モニターループを実行
-pub async fn run_loop(
-    client: &Arc<ProtocolClient>,
-    server_slug: &str,
-    config: &MonitorConfig,
-) {
+pub async fn run_loop(client: &Arc<ProtocolClient>, server_slug: &str, config: &MonitorConfig) {
     let docker = match Docker::connect_with_local_defaults() {
         Ok(d) => d,
         Err(e) => {
@@ -195,10 +191,12 @@ pub(crate) async fn check_containers(
             None => continue,
         };
 
-        let status = state.status.as_ref().map(|s| s.to_string()).unwrap_or_default();
-        let restart_count = info
-            .restart_count
-            .unwrap_or(0);
+        let status = state
+            .status
+            .as_ref()
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        let restart_count = info.restart_count.unwrap_or(0);
         let health = state
             .health
             .as_ref()
@@ -268,10 +266,7 @@ pub(crate) fn detect_anomalies(
             container_name: container_name.to_string(),
             alert_type: AlertType::Unhealthy,
             severity: Severity::Warning,
-            message: format!(
-                "コンテナ {} が unhealthy",
-                container_name
-            ),
+            message: format!("コンテナ {} が unhealthy", container_name),
         });
     }
 

--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -1,0 +1,491 @@
+//! ヘルスモニター — Docker コンテナ状態監視 + 異常検知 + CP アラート送信
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bollard::Docker;
+use bollard::query_parameters::{InspectContainerOptions, ListContainersOptions};
+use serde_json::json;
+use tracing::{debug, error, info, warn};
+use unison::network::client::ProtocolClient;
+
+/// モニター設定
+#[derive(Debug, Clone)]
+pub struct MonitorConfig {
+    /// 監視間隔（秒）
+    pub interval_secs: u64,
+    /// リスタート閾値（この回数を超えたらアラート）
+    pub restart_threshold: u32,
+    /// アラートクールダウン（秒）— 同一コンテナ・同一アラートの重複抑制
+    pub alert_cooldown_secs: u64,
+}
+
+impl Default for MonitorConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: 30,
+            restart_threshold: 3,
+            alert_cooldown_secs: 300,
+        }
+    }
+}
+
+/// コンテナ状態（前回値との比較に使用）
+#[derive(Debug, Clone)]
+pub(crate) struct ContainerState {
+    status: String,
+    restart_count: i64,
+    health: Option<String>,
+}
+
+/// 検知されたアラート
+#[derive(Debug, Clone, PartialEq)]
+pub struct DetectedAlert {
+    pub container_name: String,
+    pub alert_type: AlertType,
+    pub severity: Severity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AlertType {
+    RestartLoop,
+    UnexpectedStop,
+    Unhealthy,
+}
+
+impl AlertType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RestartLoop => "restart_loop",
+            Self::UnexpectedStop => "unexpected_stop",
+            Self::Unhealthy => "unhealthy",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Severity {
+    Warning,
+    Critical,
+}
+
+impl Severity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Warning => "warning",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+/// クールダウンキー: (container_name, alert_type)
+type CooldownKey = (String, String);
+
+/// モニターループを実行
+pub async fn run_loop(
+    client: &Arc<ProtocolClient>,
+    server_slug: &str,
+    config: &MonitorConfig,
+) {
+    let docker = match Docker::connect_with_local_defaults() {
+        Ok(d) => d,
+        Err(e) => {
+            error!(error = %e, "Docker 接続失敗 — モニター停止");
+            return;
+        }
+    };
+
+    info!(
+        interval = config.interval_secs,
+        threshold = config.restart_threshold,
+        "ヘルスモニター開始"
+    );
+
+    let mut prev_states: HashMap<String, ContainerState> = HashMap::new();
+    let mut cooldowns: HashMap<CooldownKey, Instant> = HashMap::new();
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(config.interval_secs)).await;
+
+        match check_containers(&docker, &prev_states, config).await {
+            Ok((alerts, new_states)) => {
+                for alert in &alerts {
+                    let key = (
+                        alert.container_name.clone(),
+                        alert.alert_type.as_str().to_string(),
+                    );
+
+                    // クールダウンチェック
+                    if let Some(last_sent) = cooldowns.get(&key) {
+                        if last_sent.elapsed() < Duration::from_secs(config.alert_cooldown_secs) {
+                            debug!(
+                                container = %alert.container_name,
+                                alert_type = alert.alert_type.as_str(),
+                                "クールダウン中 — アラートスキップ"
+                            );
+                            continue;
+                        }
+                    }
+
+                    // CP にアラート送信
+                    if let Err(e) = send_alert(client, server_slug, alert).await {
+                        warn!(error = %e, "アラート送信失敗");
+                    } else {
+                        cooldowns.insert(key, Instant::now());
+                        info!(
+                            container = %alert.container_name,
+                            alert_type = alert.alert_type.as_str(),
+                            severity = alert.severity.as_str(),
+                            "アラート送信完了"
+                        );
+                    }
+                }
+                prev_states = new_states;
+            }
+            Err(e) => {
+                warn!(error = %e, "コンテナチェック失敗");
+            }
+        }
+    }
+}
+
+/// 全コンテナを取得し、前回状態と比較して異常を検知
+pub(crate) async fn check_containers(
+    docker: &Docker,
+    prev_states: &HashMap<String, ContainerState>,
+    config: &MonitorConfig,
+) -> anyhow::Result<(Vec<DetectedAlert>, HashMap<String, ContainerState>)> {
+    let containers = docker
+        .list_containers(Some(ListContainersOptions {
+            all: true,
+            ..Default::default()
+        }))
+        .await?;
+
+    let mut alerts = Vec::new();
+    let mut new_states = HashMap::new();
+
+    for container in &containers {
+        let name = match container.names.as_ref().and_then(|n| n.first()) {
+            Some(n) => n.trim_start_matches('/').to_string(),
+            None => continue,
+        };
+
+        let id = match &container.id {
+            Some(id) => id,
+            None => continue,
+        };
+
+        // inspect で詳細取得
+        let info = match docker
+            .inspect_container(id, None::<InspectContainerOptions>)
+            .await
+        {
+            Ok(info) => info,
+            Err(e) => {
+                debug!(container = %name, error = %e, "inspect 失敗 — スキップ");
+                continue;
+            }
+        };
+
+        let state = match &info.state {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let status = state.status.as_ref().map(|s| s.to_string()).unwrap_or_default();
+        let restart_count = info
+            .restart_count
+            .unwrap_or(0);
+        let health = state
+            .health
+            .as_ref()
+            .and_then(|h| h.status.as_ref())
+            .map(|s| s.to_string());
+
+        let current = ContainerState {
+            status: status.clone(),
+            restart_count,
+            health: health.clone(),
+        };
+
+        // 異常検知
+        let detected = detect_anomalies(&name, &current, prev_states.get(&name), config);
+        alerts.extend(detected);
+
+        new_states.insert(name, current);
+    }
+
+    Ok((alerts, new_states))
+}
+
+/// 異常検知ロジック
+pub(crate) fn detect_anomalies(
+    container_name: &str,
+    current: &ContainerState,
+    previous: Option<&ContainerState>,
+    config: &MonitorConfig,
+) -> Vec<DetectedAlert> {
+    let mut alerts = Vec::new();
+
+    // 1. restart_loop: リスタート回数が閾値超え & 前回から増加
+    if current.restart_count > config.restart_threshold as i64 {
+        let prev_count = previous.map(|p| p.restart_count).unwrap_or(0);
+        if current.restart_count > prev_count {
+            alerts.push(DetectedAlert {
+                container_name: container_name.to_string(),
+                alert_type: AlertType::RestartLoop,
+                severity: Severity::Critical,
+                message: format!(
+                    "コンテナ {} がリスタートループ: {} 回（閾値: {}）",
+                    container_name, current.restart_count, config.restart_threshold
+                ),
+            });
+        }
+    }
+
+    // 2. unexpected_stop: running → exited/dead
+    if let Some(prev) = previous
+        && prev.status == "running"
+        && (current.status == "exited" || current.status == "dead")
+    {
+        alerts.push(DetectedAlert {
+            container_name: container_name.to_string(),
+            alert_type: AlertType::UnexpectedStop,
+            severity: Severity::Critical,
+            message: format!(
+                "コンテナ {} が予期しない停止: {} → {}",
+                container_name, prev.status, current.status
+            ),
+        });
+    }
+
+    // 3. unhealthy: Docker ヘルスチェック
+    if current.health.as_deref() == Some("unhealthy") {
+        alerts.push(DetectedAlert {
+            container_name: container_name.to_string(),
+            alert_type: AlertType::Unhealthy,
+            severity: Severity::Warning,
+            message: format!(
+                "コンテナ {} が unhealthy",
+                container_name
+            ),
+        });
+    }
+
+    alerts
+}
+
+/// CP にアラートを送信
+async fn send_alert(
+    client: &ProtocolClient,
+    server_slug: &str,
+    alert: &DetectedAlert,
+) -> anyhow::Result<()> {
+    let channel = client.open_channel("server").await?;
+
+    channel
+        .request(
+            "alert",
+            json!({
+                "server_slug": server_slug,
+                "container_name": alert.container_name,
+                "alert_type": alert.alert_type.as_str(),
+                "severity": alert.severity.as_str(),
+                "message": alert.message,
+            }),
+        )
+        .await?;
+
+    channel.close().await.ok();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> MonitorConfig {
+        MonitorConfig {
+            interval_secs: 30,
+            restart_threshold: 3,
+            alert_cooldown_secs: 300,
+        }
+    }
+
+    #[test]
+    fn test_detect_restart_loop() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "running".into(),
+            restart_count: 5,
+            health: None,
+        };
+        let previous = ContainerState {
+            status: "running".into(),
+            restart_count: 3,
+            health: None,
+        };
+
+        let alerts = detect_anomalies("web", &current, Some(&previous), &config);
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].alert_type, AlertType::RestartLoop);
+        assert_eq!(alerts[0].severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_no_restart_loop_below_threshold() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "running".into(),
+            restart_count: 2,
+            health: None,
+        };
+
+        let alerts = detect_anomalies("web", &current, None, &config);
+        assert!(alerts.is_empty());
+    }
+
+    #[test]
+    fn test_no_restart_loop_same_count() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "running".into(),
+            restart_count: 5,
+            health: None,
+        };
+        let previous = ContainerState {
+            status: "running".into(),
+            restart_count: 5,
+            health: None,
+        };
+
+        let alerts = detect_anomalies("web", &current, Some(&previous), &config);
+        assert!(alerts.is_empty());
+    }
+
+    #[test]
+    fn test_detect_unexpected_stop() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "exited".into(),
+            restart_count: 0,
+            health: None,
+        };
+        let previous = ContainerState {
+            status: "running".into(),
+            restart_count: 0,
+            health: None,
+        };
+
+        let alerts = detect_anomalies("db", &current, Some(&previous), &config);
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].alert_type, AlertType::UnexpectedStop);
+    }
+
+    #[test]
+    fn test_detect_unexpected_stop_dead() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "dead".into(),
+            restart_count: 0,
+            health: None,
+        };
+        let previous = ContainerState {
+            status: "running".into(),
+            restart_count: 0,
+            health: None,
+        };
+
+        let alerts = detect_anomalies("db", &current, Some(&previous), &config);
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].alert_type, AlertType::UnexpectedStop);
+    }
+
+    #[test]
+    fn test_no_unexpected_stop_without_previous() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "exited".into(),
+            restart_count: 0,
+            health: None,
+        };
+
+        let alerts = detect_anomalies("db", &current, None, &config);
+        assert!(alerts.is_empty());
+    }
+
+    #[test]
+    fn test_detect_unhealthy() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "running".into(),
+            restart_count: 0,
+            health: Some("unhealthy".into()),
+        };
+
+        let alerts = detect_anomalies("api", &current, None, &config);
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].alert_type, AlertType::Unhealthy);
+        assert_eq!(alerts[0].severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_healthy_container_no_alerts() {
+        let config = default_config();
+        let current = ContainerState {
+            status: "running".into(),
+            restart_count: 0,
+            health: Some("healthy".into()),
+        };
+        let previous = ContainerState {
+            status: "running".into(),
+            restart_count: 0,
+            health: Some("healthy".into()),
+        };
+
+        let alerts = detect_anomalies("api", &current, Some(&previous), &config);
+        assert!(alerts.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_anomalies() {
+        let config = default_config();
+        // restart_loop + unhealthy 同時検知
+        let current = ContainerState {
+            status: "running".into(),
+            restart_count: 10,
+            health: Some("unhealthy".into()),
+        };
+        let previous = ContainerState {
+            status: "running".into(),
+            restart_count: 5,
+            health: Some("healthy".into()),
+        };
+
+        let alerts = detect_anomalies("api", &current, Some(&previous), &config);
+        assert_eq!(alerts.len(), 2);
+
+        let types: Vec<_> = alerts.iter().map(|a| &a.alert_type).collect();
+        assert!(types.contains(&&AlertType::RestartLoop));
+        assert!(types.contains(&&AlertType::Unhealthy));
+    }
+
+    #[test]
+    fn test_cooldown_key_uniqueness() {
+        // CooldownKey が (container_name, alert_type) で区別されることを確認
+        let key1: CooldownKey = ("web".into(), "restart_loop".into());
+        let key2: CooldownKey = ("web".into(), "unhealthy".into());
+        let key3: CooldownKey = ("db".into(), "restart_loop".into());
+
+        let mut map: HashMap<CooldownKey, Instant> = HashMap::new();
+        map.insert(key1.clone(), Instant::now());
+        map.insert(key2.clone(), Instant::now());
+        map.insert(key3.clone(), Instant::now());
+
+        assert_eq!(map.len(), 3);
+        assert!(map.contains_key(&key1));
+    }
+}

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -806,11 +806,7 @@ impl Database {
     }
 
     /// コンテナ正常復帰時に該当アラートを解決済みにする
-    pub async fn resolve_alerts(
-        &self,
-        server_slug: &str,
-        container_name: &str,
-    ) -> Result<()> {
+    pub async fn resolve_alerts(&self, server_slug: &str, container_name: &str) -> Result<()> {
         self.db
             .query(
                 "UPDATE alert SET resolved = true, resolved_at = time::now() WHERE server_slug = $server_slug AND container_name = $container_name AND resolved = false",
@@ -833,9 +829,7 @@ impl Database {
             .await
             .context("アラートカウント取得失敗")?;
         let row: Option<serde_json::Value> = result.take(0)?;
-        Ok(row
-            .and_then(|v| v["count"].as_i64())
-            .unwrap_or(0))
+        Ok(row.and_then(|v| v["count"].as_i64()).unwrap_or(0))
     }
 }
 

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -374,7 +374,8 @@ impl Database {
                     server.status AS server_status,
                     server.last_heartbeat_at AS server_heartbeat,
                     (SELECT status, created_at FROM deployment WHERE project = $parent.project AND stage = $parent.slug ORDER BY created_at DESC LIMIT 1)[0].status AS last_deploy_status,
-                    (SELECT status, created_at FROM deployment WHERE project = $parent.project AND stage = $parent.slug ORDER BY created_at DESC LIMIT 1)[0].created_at AS last_deploy_at
+                    (SELECT status, created_at FROM deployment WHERE project = $parent.project AND stage = $parent.slug ORDER BY created_at DESC LIMIT 1)[0].created_at AS last_deploy_at,
+                    (SELECT count() FROM alert WHERE server_slug = $parent.server.slug AND resolved = false GROUP ALL)[0].count AS alert_count
                 FROM stage
                 WHERE project.tenant.slug = $tenant_slug
                 ORDER BY project_slug, slug
@@ -757,6 +758,85 @@ impl Database {
         let deployments: Vec<Deployment> = result.take(0)?;
         Ok(deployments)
     }
+
+    // ─────────────────────────────────────────
+    // Alert CRUD
+    // ─────────────────────────────────────────
+
+    /// 同一 (server_slug, container_name, alert_type) で未解決アラートがあれば更新、なければ作成
+    pub async fn upsert_alert(&self, alert: &Alert) -> Result<Alert> {
+        let mut result = self
+            .db
+            .query(
+                r#"
+                LET $existing = (SELECT * FROM alert
+                    WHERE server_slug = $server_slug
+                    AND container_name = $container_name
+                    AND alert_type = $alert_type
+                    AND resolved = false
+                    LIMIT 1);
+                IF array::len($existing) > 0 THEN
+                    (UPDATE $existing[0].id SET
+                        severity = $severity,
+                        message = $message)
+                ELSE
+                    (CREATE alert CONTENT {
+                        tenant: $tenant,
+                        server_slug: $server_slug,
+                        container_name: $container_name,
+                        alert_type: $alert_type,
+                        severity: $severity,
+                        message: $message,
+                        resolved: false
+                    })
+                END
+                "#,
+            )
+            .bind(("tenant", alert.tenant.clone()))
+            .bind(("server_slug", alert.server_slug.clone()))
+            .bind(("container_name", alert.container_name.clone()))
+            .bind(("alert_type", alert.alert_type.clone()))
+            .bind(("severity", alert.severity.clone()))
+            .bind(("message", alert.message.clone()))
+            .await
+            .context("アラート upsert 失敗")?;
+        // IF-ELSE 結果は statement index 1
+        let created: Option<Alert> = result.take(1)?;
+        created.context("アラート upsert 結果が空")
+    }
+
+    /// コンテナ正常復帰時に該当アラートを解決済みにする
+    pub async fn resolve_alerts(
+        &self,
+        server_slug: &str,
+        container_name: &str,
+    ) -> Result<()> {
+        self.db
+            .query(
+                "UPDATE alert SET resolved = true, resolved_at = time::now() WHERE server_slug = $server_slug AND container_name = $container_name AND resolved = false",
+            )
+            .bind(("server_slug", server_slug.to_string()))
+            .bind(("container_name", container_name.to_string()))
+            .await
+            .context("アラート解決失敗")?;
+        Ok(())
+    }
+
+    /// サーバーのアクティブアラート数を取得
+    pub async fn count_active_alerts_by_server(&self, server_slug: &str) -> Result<i64> {
+        let mut result = self
+            .db
+            .query(
+                "SELECT count() AS count FROM alert WHERE server_slug = $server_slug AND resolved = false GROUP ALL",
+            )
+            .bind(("server_slug", server_slug.to_string()))
+            .await
+            .context("アラートカウント取得失敗")?;
+        let row: Option<serde_json::Value> = result.take(0)?;
+        Ok(row
+            .and_then(|v| v["count"].as_i64())
+            .unwrap_or(0))
+    }
 }
 
 /// SurrealDB schema definition.
@@ -874,6 +954,19 @@ DEFINE FIELD IF NOT EXISTS started_at ON deployment TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS finished_at ON deployment TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS created_at ON deployment TYPE option<datetime> DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS idx_deployment_project_stage ON deployment FIELDS project, stage;
+
+DEFINE TABLE IF NOT EXISTS alert SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS tenant ON alert TYPE record<tenant>;
+DEFINE FIELD IF NOT EXISTS server_slug ON alert TYPE string;
+DEFINE FIELD IF NOT EXISTS container_name ON alert TYPE string;
+DEFINE FIELD IF NOT EXISTS alert_type ON alert TYPE string;
+DEFINE FIELD IF NOT EXISTS severity ON alert TYPE string DEFAULT 'warning';
+DEFINE FIELD IF NOT EXISTS message ON alert TYPE string;
+DEFINE FIELD IF NOT EXISTS resolved ON alert TYPE bool DEFAULT false;
+DEFINE FIELD IF NOT EXISTS resolved_at ON alert TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS created_at ON alert TYPE option<datetime> DEFAULT time::now();
+DEFINE INDEX IF NOT EXISTS idx_alert_tenant ON alert FIELDS tenant;
+DEFINE INDEX IF NOT EXISTS idx_alert_active ON alert FIELDS server_slug, container_name, alert_type, resolved;
 "#;
 
 #[cfg(test)]
@@ -1212,5 +1305,80 @@ mod tests {
         assert_eq!(live.server_slug.as_deref(), Some("vps-01"));
         assert_eq!(live.server_status.as_deref(), Some("online"));
         assert_eq!(live.last_deploy_status.as_deref(), Some("success"));
+    }
+
+    #[tokio::test]
+    async fn test_alert_crud() {
+        let db = Database::connect_memory().await.unwrap();
+        let tenant = create_test_tenant(&db).await;
+        let tenant_id = tenant.id.unwrap();
+
+        // サーバー作成
+        db.register_server(&Server {
+            id: None,
+            tenant: tenant_id.clone(),
+            slug: "vps-01".into(),
+            provider: "sakura-cloud".into(),
+            plan: None,
+            ssh_host: "10.0.0.1".into(),
+            ssh_user: "root".into(),
+            deploy_path: "/opt/apps".into(),
+            status: "online".into(),
+            provision_version: None,
+            tool_versions: None,
+            last_heartbeat_at: None,
+            created_at: None,
+            updated_at: None,
+        })
+        .await
+        .unwrap();
+
+        // アラート作成
+        let alert = Alert {
+            id: None,
+            tenant: tenant_id.clone(),
+            server_slug: "vps-01".into(),
+            container_name: "web".into(),
+            alert_type: "restart_loop".into(),
+            severity: "critical".into(),
+            message: "コンテナ web がリスタートループ".into(),
+            resolved: false,
+            resolved_at: None,
+            created_at: None,
+        };
+        let created = db.upsert_alert(&alert).await.unwrap();
+        assert!(created.id.is_some());
+        assert_eq!(created.server_slug, "vps-01");
+        assert_eq!(created.alert_type, "restart_loop");
+        assert!(!created.resolved);
+
+        // 同一コンテナ・同一タイプで upsert → 更新される（新規作成されない）
+        let alert2 = Alert {
+            message: "更新されたメッセージ".into(),
+            ..alert.clone()
+        };
+        let updated = db.upsert_alert(&alert2).await.unwrap();
+        assert_eq!(updated.message, "更新されたメッセージ");
+
+        // アクティブアラートカウント
+        let count = db.count_active_alerts_by_server("vps-01").await.unwrap();
+        assert_eq!(count, 1);
+
+        // 別タイプのアラートを追加
+        let alert3 = Alert {
+            alert_type: "unhealthy".into(),
+            severity: "warning".into(),
+            message: "コンテナ web が unhealthy".into(),
+            ..alert.clone()
+        };
+        db.upsert_alert(&alert3).await.unwrap();
+
+        let count = db.count_active_alerts_by_server("vps-01").await.unwrap();
+        assert_eq!(count, 2);
+
+        // 解決
+        db.resolve_alerts("vps-01", "web").await.unwrap();
+        let count = db.count_active_alerts_by_server("vps-01").await.unwrap();
+        assert_eq!(count, 0);
     }
 }

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 use unison::network::channel::UnisonChannel;
 use unison::network::server::ProtocolServer;
 
-use crate::model::{Server, ServerStatusUpdate};
+use crate::model::{Alert, Server, ServerStatusUpdate};
 use crate::server::AppState;
 
 pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
@@ -551,6 +551,85 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             msg.id,
                                             "power-off",
                                             json!({ "error": "server provider not configured" }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        "alert" => {
+                            let server_slug =
+                                payload["server_slug"].as_str().unwrap_or_default();
+                            let container_name =
+                                payload["container_name"].as_str().unwrap_or_default();
+                            let alert_type =
+                                payload["alert_type"].as_str().unwrap_or_default();
+                            let severity =
+                                payload["severity"].as_str().unwrap_or("warning");
+                            let message =
+                                payload["message"].as_str().unwrap_or_default();
+
+                            // server_slug → テナント解決
+                            let server = match state.db.get_server_by_slug(server_slug).await {
+                                Ok(Some(s)) => s,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "alert",
+                                            json!({ "error": "server not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "server lookup 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "alert",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+
+                            let alert = Alert {
+                                id: None,
+                                tenant: server.tenant.clone(),
+                                server_slug: server_slug.to_string(),
+                                container_name: container_name.to_string(),
+                                alert_type: alert_type.to_string(),
+                                severity: severity.to_string(),
+                                message: message.to_string(),
+                                resolved: false,
+                                resolved_at: None,
+                                created_at: None,
+                            };
+
+                            match state.db.upsert_alert(&alert).await {
+                                Ok(_) => {
+                                    info!(
+                                        server = server_slug,
+                                        container = container_name,
+                                        alert_type,
+                                        "アラート記録完了"
+                                    );
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "alert",
+                                            json!({ "ack": true }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "アラート記録失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "alert",
+                                            json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -89,6 +89,26 @@ impl TenantUser {
     }
 }
 
+// ─────────────────────────────────────────────
+// CP-010: Alert（コンテナアラート）
+// ─────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct Alert {
+    pub id: Option<RecordId>,
+    pub tenant: RecordId,
+    pub server_slug: String,
+    pub container_name: String,
+    /// "restart_loop" | "unexpected_stop" | "unhealthy"
+    pub alert_type: String,
+    /// "warning" | "critical"
+    pub severity: String,
+    pub message: String,
+    pub resolved: bool,
+    pub resolved_at: Option<DateTime<Utc>>,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
 /// テナント解決結果（auth middleware → handler 受け渡し用）
 #[derive(Debug, Clone)]
 pub struct AuthContext {
@@ -176,6 +196,8 @@ pub struct StageOverview {
     pub last_deploy_status: Option<String>,
     /// 直近デプロイの時刻
     pub last_deploy_at: Option<DateTime<Utc>>,
+    /// アクティブアラート数
+    pub alert_count: Option<i64>,
 }
 
 // ─────────────────────────────────────────────

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -556,23 +556,27 @@ async fn api_stages(State(state): State<Arc<WebState>>, req: Request) -> impl In
             // 優先度ソート: 異常が上に来る
             stages.sort_by(|a, b| {
                 let priority = |s: &fleetflow_controlplane::model::StageOverview| -> u8 {
+                    // アクティブアラートあり
+                    if s.alert_count.unwrap_or(0) > 0 {
+                        return 0;
+                    }
                     // デプロイ失敗
                     if s.last_deploy_status.as_deref() == Some("failed") {
-                        return 0;
+                        return 1;
                     }
                     // サーバー offline
                     if s.server_status.as_deref() == Some("offline") {
-                        return 1;
+                        return 2;
                     }
                     // デプロイ進行中
                     if matches!(
                         s.last_deploy_status.as_deref(),
                         Some("running") | Some("pending")
                     ) {
-                        return 2;
+                        return 3;
                     }
                     // 正常
-                    3
+                    4
                 };
                 priority(a).cmp(&priority(b))
             });
@@ -590,6 +594,7 @@ async fn api_stages(State(state): State<Arc<WebState>>, req: Request) -> impl In
                         "server_heartbeat": s.server_heartbeat.map(|d| d.to_rfc3339()),
                         "last_deploy_status": s.last_deploy_status,
                         "last_deploy_at": s.last_deploy_at.map(|d| d.to_rfc3339()),
+                        "alert_count": s.alert_count.unwrap_or(0),
                     })
                 })
                 .collect();


### PR DESCRIPTION
## Summary

- Fleet Agent に `monitor.rs` モジュール追加（Docker コンテナ状態監視）
- 再起動カウント追跡 + 閾値超過でアラート送信
- CP 側に alert テーブル + CRUD + ハンドラー追加
- Dashboard 1st ビューに alert_count 表示 + 優先度ソート更新

## Changes

### fleet-agent
- `src/monitor.rs` — bollard で Docker コンテナ監視ループ、異常検知ロジック
- `src/agent.rs` — モニタータスク起動
- `src/main.rs` — CLI 引数追加

### fleetflow-controlplane
- `src/model.rs` — Alert 構造体 + StageOverview.alert_count
- `src/db.rs` — alert スキーマ + DB メソッド + list_stage_overviews クエリ更新
- `src/handlers/` — alert ハンドラー

### fleetflowd
- `src/web.rs` — API レスポンスに alert_count + 優先度ソート更新

## Test plan
- [x] `cargo build` — コンパイル成功
- [x] `cargo test --lib` — 全テスト通過（419+ テスト、monitor テスト8件含む）
- [x] `cargo clippy` — 警告 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)