### PR TITLE
feat(FSC-26): Phase B-1 — Server に Worker Pool labels / capacity / allocated / scheduling を追加

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,10 @@
 
 [tools]
 # Rust toolchain
-rust = "1.94"
+# 1.95: `constant_time_eq@0.4.3` が rustc 1.95+ を要求するため bump。
+# Cargo.lock は gitignore 対象で CI は毎回 fresh resolve するため、
+# transitive dep の最新要求に追従する必要がある。
+rust = "1.95"
 
 [env]
 # Rustのデフォルト設定

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -500,7 +500,14 @@ impl Database {
     pub async fn register_server(&self, server: &Server) -> Result<Server> {
         let mut result = self
             .db
-            .query("CREATE server CONTENT { tenant: $tenant, slug: $slug, provider: $provider, plan: $plan, ssh_host: $ssh_host, ssh_user: $ssh_user, deploy_path: $deploy_path, status: $status }")
+            .query(
+                "CREATE server CONTENT { \
+                    tenant: $tenant, slug: $slug, provider: $provider, plan: $plan, \
+                    ssh_host: $ssh_host, ssh_user: $ssh_user, deploy_path: $deploy_path, \
+                    status: $status, labels: $labels, capacity: $capacity, \
+                    allocated: $allocated, scheduling: $scheduling \
+                }",
+            )
             .bind(("tenant", server.tenant.clone()))
             .bind(("slug", server.slug.clone()))
             .bind(("provider", server.provider.clone()))
@@ -509,6 +516,11 @@ impl Database {
             .bind(("ssh_user", server.ssh_user.clone()))
             .bind(("deploy_path", server.deploy_path.clone()))
             .bind(("status", server.status.clone()))
+            // FSC-26 Phase B-1: Worker Pool labels / capacity / allocated / scheduling
+            .bind(("labels", server.labels.clone()))
+            .bind(("capacity", server.capacity.clone()))
+            .bind(("allocated", server.allocated.clone()))
+            .bind(("scheduling", server.scheduling.clone()))
             .await
             .context("サーバー登録失敗")?;
         let created: Option<Server> = result.take(0)?;
@@ -922,6 +934,25 @@ DEFINE FIELD IF NOT EXISTS status ON server TYPE string DEFAULT 'offline';
 DEFINE FIELD IF NOT EXISTS provision_version ON server TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS tool_versions ON server TYPE option<object>;
 DEFINE FIELD IF NOT EXISTS last_heartbeat_at ON server TYPE option<datetime>;
+-- Worker Pool membership 判定と Placement 決定に使うラベル群 (FSC-26 Phase B-1)
+DEFINE FIELD IF NOT EXISTS labels ON server TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS labels.tier ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS labels.region ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS labels.class ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS labels.arch ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS labels.extras ON server TYPE option<object>;
+-- 物理リソース上限 (FSC-26 Phase B-1)
+DEFINE FIELD IF NOT EXISTS capacity ON server TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS capacity.cpu_cores ON server TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS capacity.memory_gb ON server TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS capacity.disk_gb ON server TYPE option<int>;
+-- 現在使用中のリソース (FSC-26 Phase B-1、2-phase placement で increment/decrement)
+DEFINE FIELD IF NOT EXISTS allocated ON server TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS allocated.cpu_cores ON server TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS allocated.memory_gb ON server TYPE option<int>;
+-- 論理スケジューリング状態 (FSC-26 Phase B-1、物理 status と直交)
+-- 'schedulable' | 'cordon' | 'drain' — k8s Node Condition + cordon/drain 相当
+DEFINE FIELD IF NOT EXISTS scheduling ON server TYPE option<string> DEFAULT 'schedulable';
 DEFINE FIELD IF NOT EXISTS created_at ON server TYPE option<datetime> DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS updated_at ON server TYPE option<datetime> DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS idx_server_tenant_slug ON server FIELDS tenant, slug UNIQUE;
@@ -1100,17 +1131,119 @@ mod tests {
             provision_version: None,
             tool_versions: None,
             last_heartbeat_at: None,
+            // FSC-26 Phase B-1: 新 field は全て None で backward-compat 動作を確認
+            labels: None,
+            capacity: None,
+            allocated: None,
+            scheduling: None,
             created_at: None,
             updated_at: None,
         };
         let created = db.register_server(&server).await.unwrap();
         assert!(created.id.is_some());
+        // Backward-compat: 新 field が None でも register 成功
+        assert!(created.labels.is_none());
+        assert!(created.capacity.is_none());
 
         db.update_server_heartbeat("vps-01").await.unwrap();
 
         let servers = db.list_servers_by_tenant("anycreative").await.unwrap();
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].slug, "vps-01");
+    }
+
+    // FSC-26 Phase B-1: Server に labels / capacity / allocated / scheduling を
+    // 付与して round-trip することを確認する
+    #[tokio::test]
+    async fn test_server_with_labels_crud() {
+        use crate::model::{ServerAllocated, ServerCapacity, ServerLabels, scheduling_state};
+
+        let db = Database::connect_memory().await.unwrap();
+
+        let tenant = db
+            .create_tenant(&Tenant {
+                id: None,
+                slug: "acme".into(),
+                name: "Acme Corp".into(),
+                auth0_org_id: None,
+                plan: "pro".into(),
+                dns_provider: None,
+                dns_domain: None,
+                dns_zone_id: None,
+                dns_api_token_encrypted: None,
+                created_at: None,
+                updated_at: None,
+            })
+            .await
+            .unwrap();
+
+        let server = Server {
+            id: None,
+            tenant: tenant.id.unwrap(),
+            slug: "worker-pro-01".into(),
+            provider: "sakura-cloud".into(),
+            plan: Some("4G/4CPU".into()),
+            ssh_host: "100.64.0.10".into(),
+            ssh_user: "root".into(),
+            deploy_path: "/opt/fleet".into(),
+            status: "online".into(),
+            provision_version: None,
+            tool_versions: None,
+            last_heartbeat_at: None,
+            labels: Some(ServerLabels {
+                tier: Some("pro".into()),
+                region: Some("tokyo".into()),
+                class: Some("dedicated".into()),
+                arch: Some("arm64".into()),
+                extras: None,
+            }),
+            capacity: Some(ServerCapacity {
+                cpu_cores: Some(4),
+                memory_gb: Some(8),
+                disk_gb: Some(80),
+            }),
+            allocated: Some(ServerAllocated {
+                cpu_cores: Some(0),
+                memory_gb: Some(0),
+            }),
+            scheduling: Some(scheduling_state::SCHEDULABLE.into()),
+            created_at: None,
+            updated_at: None,
+        };
+        let created = db.register_server(&server).await.unwrap();
+        assert!(created.id.is_some());
+
+        // Labels round-trip
+        let labels = created.labels.expect("labels should be persisted");
+        assert_eq!(labels.tier.as_deref(), Some("pro"));
+        assert_eq!(labels.region.as_deref(), Some("tokyo"));
+        assert_eq!(labels.class.as_deref(), Some("dedicated"));
+        assert_eq!(labels.arch.as_deref(), Some("arm64"));
+
+        // Capacity round-trip
+        let capacity = created.capacity.expect("capacity should be persisted");
+        assert_eq!(capacity.cpu_cores, Some(4));
+        assert_eq!(capacity.memory_gb, Some(8));
+        assert_eq!(capacity.disk_gb, Some(80));
+
+        // Allocated round-trip (初期値 0)
+        let allocated = created.allocated.expect("allocated should be persisted");
+        assert_eq!(allocated.cpu_cores, Some(0));
+        assert_eq!(allocated.memory_gb, Some(0));
+
+        // Scheduling state
+        assert_eq!(
+            created.scheduling.as_deref(),
+            Some(scheduling_state::SCHEDULABLE)
+        );
+
+        // リスト取得でも labels が保持されていること
+        let servers = db.list_servers_by_tenant("acme").await.unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(
+            servers[0].labels.as_ref().and_then(|l| l.tier.as_deref()),
+            Some("pro")
+        );
     }
 
     /// テスト用ヘルパー: テナント作成
@@ -1258,6 +1391,10 @@ mod tests {
                 provision_version: None,
                 tool_versions: None,
                 last_heartbeat_at: None,
+                labels: None,
+                capacity: None,
+                allocated: None,
+                scheduling: None,
                 created_at: None,
                 updated_at: None,
             })
@@ -1343,6 +1480,10 @@ mod tests {
             provision_version: None,
             tool_versions: None,
             last_heartbeat_at: None,
+            labels: None,
+            capacity: None,
+            allocated: None,
+            scheduling: None,
             created_at: None,
             updated_at: None,
         })

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -92,6 +92,11 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .map(String::from),
                                 tool_versions: payload.get("tool_versions").cloned(),
                                 last_heartbeat_at: None,
+                                // FSC-26 Phase B-1: register 経由では未設定、後続 API で付与
+                                labels: None,
+                                capacity: None,
+                                allocated: None,
+                                scheduling: None,
                                 created_at: None,
                                 updated_at: None,
                             };
@@ -386,6 +391,11 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 provision_version: None,
                                 tool_versions: None,
                                 last_heartbeat_at: None,
+                                // FSC-26 Phase B-1: create 経由では未設定、後続 API で付与
+                                labels: None,
+                                capacity: None,
+                                allocated: None,
+                                scheduling: None,
                                 created_at: None,
                                 updated_at: None,
                             };

--- a/crates/fleetflow-controlplane/src/log_router.rs
+++ b/crates/fleetflow-controlplane/src/log_router.rs
@@ -161,7 +161,7 @@ impl LogRouter {
         }
 
         // timestamp でソートして最新 limit 件
-        results.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        results.sort_by_key(|r| r.timestamp);
         if results.len() > limit {
             results = results.split_off(results.len() - limit);
         }

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -245,6 +245,53 @@ pub struct Container {
 // CP-006: Server
 // ─────────────────────────────────────────────
 
+/// Server labels — Worker Pool membership 判定と Placement 決定に使う
+/// (FSC-26 Phase B-1)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct ServerLabels {
+    /// Tier label: "free" / "pro" / "enterprise" 等
+    pub tier: Option<String>,
+    /// Region label: "tokyo" / "osaka" 等
+    pub region: Option<String>,
+    /// Isolation class: "shared" / "dedicated" / "isolated" / "byoc"
+    pub class: Option<String>,
+    /// CPU architecture: "amd64" / "arm64"
+    pub arch: Option<String>,
+    /// 任意拡張ラベル
+    pub extras: Option<serde_json::Value>,
+}
+
+/// Server capacity — 物理リソース上限 (FSC-26 Phase B-1)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct ServerCapacity {
+    pub cpu_cores: Option<i64>,
+    pub memory_gb: Option<i64>,
+    pub disk_gb: Option<i64>,
+}
+
+/// Server allocated — 現在使用中のリソース (FSC-26 Phase B-1)
+/// 2-phase placement の commit 時に加算され、release 時に減算される
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct ServerAllocated {
+    pub cpu_cores: Option<i64>,
+    pub memory_gb: Option<i64>,
+}
+
+/// Server scheduling state の文字列定数 (FSC-26 Phase B-1)
+/// 論理的なスケジューリング可否を表す。物理 `status` フィールドとは直交:
+/// - 物理 `status`: "online" / "offline" / ... (Tailscale / heartbeat の実態)
+/// - 論理 `scheduling`: "schedulable" / "cordon" / "drain" (Scheduler の判断)
+///
+/// k8s Node Condition + `kubectl cordon` / `kubectl drain` 相当。
+pub mod scheduling_state {
+    /// 新規配置可能、既存 placement も継続
+    pub const SCHEDULABLE: &str = "schedulable";
+    /// 新規配置停止、既存 placement は継続（計画 maintenance 前の準備）
+    pub const CORDON: &str = "cordon";
+    /// 既存 placement も退去予定、新規配置不可（廃止 or 大規模 maintenance）
+    pub const DRAIN: &str = "drain";
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
 pub struct Server {
     pub id: Option<RecordId>,
@@ -261,6 +308,15 @@ pub struct Server {
     /// ツールバージョン情報（JSON: {"docker": "29.3.0", "tailscale": "1.94.2", ...}）
     pub tool_versions: Option<serde_json::Value>,
     pub last_heartbeat_at: Option<DateTime<Utc>>,
+    /// Worker Pool membership 判定用 labels (FSC-26 Phase B-1)
+    pub labels: Option<ServerLabels>,
+    /// 物理リソース上限 (FSC-26 Phase B-1)
+    pub capacity: Option<ServerCapacity>,
+    /// 現在使用中のリソース (FSC-26 Phase B-1)
+    pub allocated: Option<ServerAllocated>,
+    /// 論理スケジューリング状態 (FSC-26 Phase B-1)
+    /// `scheduling_state` モジュールの定数を使用。None = 未指定（schedulable 扱い）
+    pub scheduling: Option<String>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
 }

--- a/crates/fleetflow/src/tui/init.rs
+++ b/crates/fleetflow/src/tui/init.rs
@@ -146,14 +146,10 @@ pub fn run_init_wizard() -> io::Result<Option<(String, String)>> {
                 KeyCode::Backspace => {
                     state.previous_step();
                 }
-                KeyCode::Down | KeyCode::Char('j')
-                    if state.step == WizardStep::SelectTemplate =>
-                {
+                KeyCode::Down | KeyCode::Char('j') if state.step == WizardStep::SelectTemplate => {
                     state.select_next_template();
                 }
-                KeyCode::Up | KeyCode::Char('k')
-                    if state.step == WizardStep::SelectTemplate =>
-                {
+                KeyCode::Up | KeyCode::Char('k') if state.step == WizardStep::SelectTemplate => {
                     state.select_previous_template();
                 }
                 KeyCode::Tab if state.step == WizardStep::SelectPath => {

--- a/crates/fleetflow/src/tui/init.rs
+++ b/crates/fleetflow/src/tui/init.rs
@@ -146,20 +146,18 @@ pub fn run_init_wizard() -> io::Result<Option<(String, String)>> {
                 KeyCode::Backspace => {
                     state.previous_step();
                 }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    if state.step == WizardStep::SelectTemplate {
-                        state.select_next_template();
-                    }
+                KeyCode::Down | KeyCode::Char('j')
+                    if state.step == WizardStep::SelectTemplate =>
+                {
+                    state.select_next_template();
                 }
-                KeyCode::Up | KeyCode::Char('k') => {
-                    if state.step == WizardStep::SelectTemplate {
-                        state.select_previous_template();
-                    }
+                KeyCode::Up | KeyCode::Char('k')
+                    if state.step == WizardStep::SelectTemplate =>
+                {
+                    state.select_previous_template();
                 }
-                KeyCode::Tab => {
-                    if state.step == WizardStep::SelectPath {
-                        state.cycle_config_path();
-                    }
+                KeyCode::Tab if state.step == WizardStep::SelectPath => {
+                    state.cycle_config_path();
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary

FSC-26 (Worker Pool + Scheduler 導入、NewSQL PD モデル) の **Phase B-1** として、Worker Pool 設計の基盤 field 群を `Server` model + SurrealDB schema に追加。**純加算のため既存 CRUD 動作に影響なし**、backward-compat を test で担保。

## 背景

fleetstage 側 Phase A 設計メモ [`docs/design/NEWSQL-WORKER-POOL.md`](https://github.com/chronista-club/fleetstage/blob/main/docs/design/NEWSQL-WORKER-POOL.md) §4-1 に基づく実装。VPS Worker Pool × Fleet Compute の 2 層分離を実現するための基礎データ構造。

## 追加内容

### Sub-struct (`model.rs`)

| struct | 役割 | fields |
|--------|------|-------|
| `ServerLabels` | Pool membership 判定用ラベル | `tier` / `region` / `class` / `arch` / `extras` |
| `ServerCapacity` | 物理リソース上限 | `cpu_cores` / `memory_gb` / `disk_gb` |
| `ServerAllocated` | 現在使用中リソース (2-phase placement で増減予定) | `cpu_cores` / `memory_gb` |
| `scheduling_state` モジュール | 論理 scheduling state の文字列定数 | `SCHEDULABLE` / `CORDON` / `DRAIN` |

### `Server` struct 拡張 (4 Option field)

- `labels: Option<ServerLabels>`
- `capacity: Option<ServerCapacity>`
- `allocated: Option<ServerAllocated>`
- `scheduling: Option<String>` — 論理 scheduling 状態（物理 `status` と直交、k8s Node cordon/drain 相当）

### SCHEMA_SQL 拡張 (`db.rs`、`IF NOT EXISTS` 方式)

- `server` テーブルに `labels` / `capacity` / `allocated` の nested object fields
- `scheduling: option<string> DEFAULT 'schedulable'`

## Tests

- `test_server_with_labels_crud` 新設: labels/capacity/allocated/scheduling の round-trip、`list_servers_by_tenant` での保持も確認
- `test_server_crud` を新 field = None で更新: **backward-compat を test で担保**

## Test 結果 (local)

```
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s
```

## Phase 連鎖 (親 FSC-26)

| Sub-PR | スコープ | 状態 |
|--------|---------|------|
| **B-1 (本 PR)** | Server labels/capacity/allocated/scheduling | ✅ 提出 |
| B-2 | `worker_pool` テーブル新設 + `server.pool_id` 参照 | 予定（B-1 merge 後） |
| B-3 | `tenant.placement_policy` | 予定（B-1 merge 後） |
| B-4 | `placement_reservation` + `placement` テーブル | 予定（B-2, B-3 後） |

## 検証

- [x] `cargo build -p fleetflow-controlplane`
- [x] `cargo test -p fleetflow-controlplane --lib` (22 passed)
- [x] `cargo clippy -p fleetflow-controlplane -- -D warnings`
- [x] `cargo fmt --all -- --check`

## 参照

- Linear: https://linear.app/chronista/issue/FSC-26
- Phase A 設計メモ: [fleetstage docs/design/NEWSQL-WORKER-POOL.md](https://github.com/chronista-club/fleetstage/blob/main/docs/design/NEWSQL-WORKER-POOL.md)
- VISION: [fleetstage docs/VISION.md](https://github.com/chronista-club/fleetstage/blob/main/docs/VISION.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)