### PR TITLE
feat(auth): Creo ID / FleetStage Control Plane を CLI/daemon default に

### DIFF
--- a/crates/fleetflow/src/commands/auth.rs
+++ b/crates/fleetflow/src/commands/auth.rs
@@ -3,10 +3,17 @@ use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-/// Auth0 のデフォルト設定
+/// Auth0 のデフォルト設定 (Creo ID / FleetStage Control Plane)
+///
+/// OSS 利用者は下記 env var で上書き可能:
+///   - `FLEETFLOW_AUTH0_DOMAIN`
+///   - `FLEETFLOW_AUTH0_CLIENT_ID`
+///   - `FLEETFLOW_AUTH0_AUDIENCE`
+///   - `FLEETFLOW_CP_ENDPOINT`
 const AUTH0_DOMAIN: &str = "anycreative.jp.auth0.com";
-const AUTH0_CLIENT_ID: &str = "fleetflow-cli";
-const AUTH0_AUDIENCE: &str = "https://api.fleetflow.run";
+const AUTH0_CLIENT_ID: &str = "u3pDPrEoMl5lb9kSa0qHU9g8cDDN9I7N";
+const AUTH0_AUDIENCE: &str = "https://api.fleetstage.cloud";
+const DEFAULT_CP_ENDPOINT: &str = "https://cp.fleetstage.cloud:4510";
 
 /// Credentials file path: ~/.config/fleetflow/credentials.json
 fn credentials_path() -> Result<PathBuf> {
@@ -59,7 +66,9 @@ struct TokenErrorResponse {
 
 /// `fleet cp login` — Auth0 Device Authorization Flow
 pub async fn handle_login(api_endpoint: Option<String>) -> Result<()> {
-    let endpoint = api_endpoint.unwrap_or_else(|| "https://api.fleetflow.run:4510".into());
+    let endpoint = api_endpoint
+        .or_else(|| std::env::var("FLEETFLOW_CP_ENDPOINT").ok())
+        .unwrap_or_else(|| DEFAULT_CP_ENDPOINT.into());
     let auth0_domain =
         std::env::var("FLEETFLOW_AUTH0_DOMAIN").unwrap_or_else(|_| AUTH0_DOMAIN.into());
     let client_id =

--- a/crates/fleetflowd/fleetflowd.example.kdl
+++ b/crates/fleetflowd/fleetflowd.example.kdl
@@ -27,9 +27,10 @@ database {
 }
 
 auth {
-    // Auth0 テナント設定
-    domain "anycreative.auth0.com"
-    audience "https://api.fleetflow.dev"
+    // Auth0 テナント設定 (Creo ID / FleetStage Control Plane)
+    // OSS 利用者は自前 Auth0 tenant に差し替え可
+    domain "anycreative.jp.auth0.com"
+    audience "https://api.fleetstage.cloud"
 }
 
 // health {

--- a/fleetflowd.kdl
+++ b/fleetflowd.kdl
@@ -21,7 +21,7 @@ web {
 
 auth {
     domain "anycreative.jp.auth0.com"
-    audience "https://api.fleetflow.run"
+    audience "https://api.fleetstage.cloud"
 }
 
 cloud {

--- a/infra/fleetflowd-local.kdl
+++ b/infra/fleetflowd-local.kdl
@@ -21,5 +21,5 @@ web {
 
 auth {
     domain "anycreative.jp.auth0.com"
-    audience "https://api.fleetflow.run"
+    audience "https://api.fleetstage.cloud"
 }


### PR DESCRIPTION
## Summary

- `fleet cp login` (Auth0 Device Flow) の既定 client_id / audience を Creo ID (`anycreative.jp.auth0.com`) + 新規作成した `Creo ID — FleetStage CLI` Native app + 新 audience `https://api.fleetstage.cloud` に切替
- 旧既定 `client_id = "fleetflow-cli"` は Auth0 に未登録で動作しなかった placeholder。`audience = "https://api.fleetflow.run"` も fleetstage.cloud 統一方針 (下流 fleetstage `FSC-27`) で廃止予定
- `fleetflowd` 側 KDL config 既定 audience も揃えて整合を取る
- OSS 利用者は env / KDL config で任意の Auth0 tenant に上書き可能 (既存の override pattern 継続)

## Changes

### `crates/fleetflow/src/commands/auth.rs`
- `AUTH0_CLIENT_ID`: `"fleetflow-cli"` → `"u3pDPrEoMl5lb9kSa0qHU9g8cDDN9I7N"` (Auth0 `Creo ID — FleetStage CLI` Native app)
- `AUTH0_AUDIENCE`: `"https://api.fleetflow.run"` → `"https://api.fleetstage.cloud"`
- 新 `DEFAULT_CP_ENDPOINT = "https://cp.fleetstage.cloud:4510"` 追加、旧 `handle_login` 内ハードコード除去
- `FLEETFLOW_CP_ENDPOINT` env override 追加 (既存の `FLEETFLOW_AUTH0_*` env override と対称)

### `fleetflowd.kdl` / `infra/fleetflowd-local.kdl` / `crates/fleetflowd/fleetflowd.example.kdl`
- `auth { audience }` を `https://api.fleetstage.cloud` に統一
- example file の domain も `anycreative.auth0.com` → `anycreative.jp.auth0.com` に修正 (以前から不整合)

## Test plan

- [x] `cargo check --workspace` 通過
- [x] `cargo clippy -p fleetflow -- -D warnings` 通過
- [ ] (post-merge) fleetflow-cp VM の config を新 audience に差し替え、`fleet cp login` で token 取得〜 CP 疎通確認
- [ ] (post-merge) OSS 利用者の env override 動作確認 (`FLEETFLOW_AUTH0_AUDIENCE=... fleet cp login`)

## Related

- fleetstage `FSC-27` — fleetstage.cloud 一本化 (fleetflow.run 廃止)
- Auth0 artifacts (anycreative tenant):
  - API resource `69e73816343a17429f18920e` / identifier `https://api.fleetstage.cloud` / 6 scopes + offline_access
  - Native app `u3pDPrEoMl5lb9kSa0qHU9g8cDDN9I7N` (Device Code + Refresh Token grants)
  - Client grant `cgr_0FgaKakTgj3O7cDC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)