### PR TITLE
fix(fleetflowd): axum 0.8 path syntax — `:param` → `{param}`

### DIFF
--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -64,30 +64,30 @@ pub async fn start(
             get(api_tenant_users).post(api_tenant_users_create),
         )
         .route(
-            "/api/tenant/users/:sub",
+            "/api/tenant/users/{sub}",
             axum::routing::put(api_tenant_users_update).delete(api_tenant_users_delete),
         )
         .route(
-            "/api/stages/:project/:stage/services",
+            "/api/stages/{project}/{stage}/services",
             get(api_stage_services),
         )
         .route(
-            "/api/stages/:project/:stage/deployments",
+            "/api/stages/{project}/{stage}/deployments",
             get(api_stage_deployments),
         )
-        .route("/api/deployments/:id/log", get(api_deployment_log))
+        .route("/api/deployments/{id}/log", get(api_deployment_log))
         .route(
-            "/api/stages/:project/:stage/redeploy",
+            "/api/stages/{project}/{stage}/redeploy",
             post(api_stage_redeploy),
         )
         .route(
-            "/api/stages/:project/:stage/restart/:service",
+            "/api/stages/{project}/{stage}/restart/{service}",
             post(api_service_restart),
         )
-        .route("/api/stages/:project/:stage/alerts", get(api_stage_alerts))
+        .route("/api/stages/{project}/{stage}/alerts", get(api_stage_alerts))
         .route("/api/agents", get(api_agents))
         .route(
-            "/api/stages/:project/:stage/logs/:container",
+            "/api/stages/{project}/{stage}/logs/{container}",
             get(api_container_logs),
         )
         .route("/api/dns/sync", post(api_dns_sync))

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -84,7 +84,10 @@ pub async fn start(
             "/api/stages/{project}/{stage}/restart/{service}",
             post(api_service_restart),
         )
-        .route("/api/stages/{project}/{stage}/alerts", get(api_stage_alerts))
+        .route(
+            "/api/stages/{project}/{stage}/alerts",
+            get(api_stage_alerts),
+        )
         .route("/api/agents", get(api_agents))
         .route(
             "/api/stages/{project}/{stage}/logs/{container}",


### PR DESCRIPTION
## Summary

v0.14.2 で axum を 0.8 に bump した際、path capture syntax が `:foo` → `{foo}` に変更された breaking change に route 文字列が追従していない。起動直後に panic する:

```
thread 'main' panicked at crates/fleetflowd/src/web.rs:66:10:
Path segments must not start with `:`. For capture groups, use `{capture}`.
```

## Changes

`crates/fleetflowd/src/web.rs` の 8 route を `{foo}` 形式に移行:

| before | after |
|--------|-------|
| `/api/tenant/users/:sub` | `/api/tenant/users/{sub}` |
| `/api/stages/:project/:stage/services` | `/api/stages/{project}/{stage}/services` |
| `/api/stages/:project/:stage/deployments` | `/api/stages/{project}/{stage}/deployments` |
| `/api/deployments/:id/log` | `/api/deployments/{id}/log` |
| `/api/stages/:project/:stage/redeploy` | `/api/stages/{project}/{stage}/redeploy` |
| `/api/stages/:project/:stage/restart/:service` | `/api/stages/{project}/{stage}/restart/{service}` |
| `/api/stages/:project/:stage/alerts` | `/api/stages/{project}/{stage}/alerts` |
| `/api/stages/:project/:stage/logs/:container` | `/api/stages/{project}/{stage}/logs/{container}` |

## Test plan

- [x] fleetflow-cp VM (Sakura tk1a) に deploy → systemd active (running)、QUIC server bound to [::]:4510、DB 接続 OK
- [x] `rg "\"/[^\"]*/:"` で全 `:param` 形式の残存なし確認

## Context

fleetflow-cp (v0.11.0) → v0.14.2 bump 作業で発覚。axum minor bump の breaking change は string literal route なので compile 時には検出されず、**起動直後の runtime panic** でのみ見える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)