### PR TITLE
feat(volume): Persistence Volume Tier P-2 — adopt CLI + REST + Unison handler

### DIFF
--- a/crates/fleetflow-controlplane/src/handlers/mod.rs
+++ b/crates/fleetflow-controlplane/src/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod server;
 pub mod service;
 pub mod stage;
 pub mod tenant;
+pub mod volume;
 
 use std::sync::Arc;
 use unison::network::server::ProtocolServer;
@@ -28,4 +29,5 @@ pub async fn register_all(server: &ProtocolServer, state: Arc<AppState>) {
     dns::register(server, state.clone()).await;
     deploy::register(server, state.clone()).await;
     agent::register(server, state.clone()).await;
+    volume::register(server, state.clone()).await;
 }

--- a/crates/fleetflow-controlplane/src/handlers/volume.rs
+++ b/crates/fleetflow-controlplane/src/handlers/volume.rs
@@ -1,0 +1,220 @@
+//! Volume channel handler (Persistence Volume Tier P-2, 2026-04-23)
+//!
+//! `fleet cp volume <subcommand>` からの Unison Protocol リクエストを処理する。
+//! 既存 disk を fleetstage registry に adopt する BYO 経路 + 一覧取得を提供。
+//!
+//! 詳細設計: fleetstage repo `docs/design/20-persistence-volume-tier.md`
+
+use std::sync::Arc;
+
+use serde_json::json;
+use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
+
+use crate::model::volume_tier;
+use crate::server::AppState;
+
+pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
+    server
+        .register_channel("volume", move |_ctx, stream| {
+            let state = state.clone();
+            Box::pin(async move {
+                let channel = UnisonChannel::new(stream);
+                loop {
+                    let msg = channel.recv().await?;
+                    let payload = msg.payload_as_value()?;
+
+                    match msg.method.as_str() {
+                        "list" => {
+                            let tenant_slug = payload["tenant_slug"].as_str().unwrap_or_default();
+
+                            let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
+                                Ok(Some(t)) => t,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "error": "tenant not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "tenant lookup 失敗 (volume.list)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            let tenant_id = tenant.id.expect("tenant.id");
+
+                            match state.db.list_volumes_by_tenant(&tenant_id).await {
+                                Ok(volumes) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "volumes": volumes }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "volume.list 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        "adopt" => {
+                            let tenant_slug = payload["tenant_slug"].as_str().unwrap_or_default();
+                            let server_slug = payload["server_slug"].as_str().unwrap_or_default();
+                            let slug = payload["slug"].as_str().unwrap_or_default();
+                            let mount = payload["mount"].as_str().unwrap_or_default();
+                            let tier = payload["tier"]
+                                .as_str()
+                                .unwrap_or(volume_tier::LOCAL_VOLUME);
+
+                            // 簡易 validation
+                            for (name, value) in [
+                                ("tenant_slug", tenant_slug),
+                                ("server_slug", server_slug),
+                                ("slug", slug),
+                                ("mount", mount),
+                            ] {
+                                if value.is_empty() {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": format!("`{}` required", name) }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            }
+
+                            let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
+                                Ok(Some(t)) => t,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": "tenant not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "tenant lookup 失敗 (volume.adopt)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            let tenant_id = tenant.id.expect("tenant.id");
+
+                            let srv = match state.db.get_server_by_slug(server_slug).await {
+                                Ok(Some(s)) => s,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({
+                                                "error": format!("server `{}` not found", server_slug)
+                                            }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "server lookup 失敗 (volume.adopt)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            if srv.tenant != tenant_id {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "adopt",
+                                        json!({
+                                            "error": "server does not belong to this tenant"
+                                        }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+                            let server_id = srv.id.expect("server.id");
+
+                            match state
+                                .db
+                                .adopt_volume(&tenant_id, &server_id, slug, mount, tier)
+                                .await
+                            {
+                                Ok(volume) => {
+                                    info!(
+                                        slug = %volume.slug,
+                                        tier = %volume.tier,
+                                        server = %server_slug,
+                                        "volume adopted (BYO)"
+                                    );
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "volume": volume }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "volume.adopt 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        other => {
+                            channel
+                                .send_response(
+                                    msg.id,
+                                    other,
+                                    json!({ "error": format!("unknown method: {}", other) }),
+                                )
+                                .await?;
+                        }
+                    }
+                }
+            })
+        })
+        .await;
+}

--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 use super::cp_client;
 use crate::{
     CostCommands, DnsCommands, ProjectCommands, RemoteCommands, ServerCommands, TenantCommands,
+    VolumeCommands,
 };
 
 pub async fn handle_tenant(cmd: &TenantCommands) -> Result<()> {
@@ -704,5 +705,119 @@ pub async fn handle_remote(cmd: &RemoteCommands) -> Result<()> {
     }
 
     client.disconnect().await.ok();
+    Ok(())
+}
+
+/// Persistence Volume コマンド (Tier P-2, 2026-04-23)
+pub async fn handle_volume(cmd: &VolumeCommands) -> Result<()> {
+    match cmd {
+        VolumeCommands::List => {
+            let (client, creds) = cp_client::connect().await?;
+
+            println!("{}", "Volume 一覧".bold());
+            println!();
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+            let resp = cp_client::request(
+                &client,
+                "volume",
+                "list",
+                json!({ "tenant_slug": tenant_slug }),
+            )
+            .await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+                client.disconnect().await.ok();
+                return Ok(());
+            }
+
+            if let Some(volumes) = resp["volumes"].as_array() {
+                if volumes.is_empty() {
+                    println!("{}", "Volume がありません。".dimmed());
+                } else {
+                    println!(
+                        "{}",
+                        format!(
+                            "{:<20} {:<16} {:<30} {:<10} {:<6}",
+                            "SLUG", "TIER", "MOUNT", "STATE", "BYO"
+                        )
+                        .bold()
+                    );
+                    println!("{}", "─".repeat(88).dimmed());
+                    for v in volumes {
+                        println!(
+                            "{:<20} {:<16} {:<30} {:<10} {:<6}",
+                            v["slug"].as_str().unwrap_or("-").cyan(),
+                            v["tier"].as_str().unwrap_or("-"),
+                            v["mount"].as_str().unwrap_or("-").dimmed(),
+                            v["state"].as_str().unwrap_or("-"),
+                            if v["bring_your_own"].as_bool().unwrap_or(false) {
+                                "yes".yellow().to_string()
+                            } else {
+                                "no".dimmed().to_string()
+                            },
+                        );
+                    }
+                }
+            }
+
+            client.disconnect().await.ok();
+        }
+        VolumeCommands::Adopt {
+            slug,
+            server,
+            mount,
+            tier,
+        } => {
+            let (client, creds) = cp_client::connect().await?;
+
+            println!("{}", "Volume adopt (BYO)".bold());
+            println!("  データには一切触れません。CP registry に record を作成します。");
+            println!();
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+            let resp = cp_client::request(
+                &client,
+                "volume",
+                "adopt",
+                json!({
+                    "tenant_slug": tenant_slug,
+                    "server_slug": server,
+                    "slug": slug,
+                    "mount": mount,
+                    "tier": tier,
+                }),
+            )
+            .await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+            } else if let Some(volume) = resp.get("volume") {
+                println!("{}", "Adopted 🎉".green().bold());
+                println!(
+                    "  Slug:   {}",
+                    volume["slug"].as_str().unwrap_or("N/A").cyan()
+                );
+                println!("  Tier:   {}", volume["tier"].as_str().unwrap_or("N/A"));
+                println!(
+                    "  Mount:  {}",
+                    volume["mount"].as_str().unwrap_or("N/A").dimmed()
+                );
+                println!("  Server: {}", server.cyan());
+                println!(
+                    "  BYO:    {}",
+                    if volume["bring_your_own"].as_bool().unwrap_or(false) {
+                        "yes".yellow().to_string()
+                    } else {
+                        "no".dimmed().to_string()
+                    }
+                );
+            }
+
+            client.disconnect().await.ok();
+        }
+    }
+
     Ok(())
 }

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -278,6 +278,9 @@ enum CpCommands {
     /// Fleet Registry 管理
     #[command(subcommand)]
     Registry(RegistryCommands),
+    /// Persistence Volume 管理 (Disk Tier、BYO 登録ほか)
+    #[command(subcommand)]
+    Volume(VolumeCommands),
 }
 
 /// デーモン管理のサブコマンド
@@ -482,6 +485,35 @@ enum RegistryCommands {
         /// 確認なしで実行
         #[arg(short, long)]
         yes: bool,
+    },
+}
+
+/// Persistence Volume 管理のサブコマンド
+///
+/// Disk Tier (ephemeral / local-volume / attached-disk / object-backed / managed-cloud)
+/// の volume を操作する。詳細: fleetstage repo docs/design/20-persistence-volume-tier.md
+#[derive(Subcommand)]
+pub enum VolumeCommands {
+    /// テナント配下の volume 一覧
+    List,
+    /// 既存 disk を fleetstage registry に adopt (BYO, データ非接触)
+    ///
+    /// tenant が既に自前で運用している disk (例: Creo Memories の既存 SurrealDB
+    /// データが格納された VPS 内 mount) を、fleetstage 管理下に登録する。
+    /// データには一切触れず、CP DB に record を作るのみ。
+    Adopt {
+        /// Volume の slug (tenant 内でユニーク)
+        #[arg(long)]
+        slug: String,
+        /// adopt 対象の server slug (該当 disk がマウントされている VPS)
+        #[arg(long)]
+        server: String,
+        /// コンテナにマウントされる path (例: /var/lib/surrealdb/prod)
+        #[arg(long)]
+        mount: String,
+        /// Disk Tier (local-volume 固定推奨、attached-disk 等は P-4 以降)
+        #[arg(long, default_value = "local-volume")]
+        tier: String,
     },
 }
 
@@ -851,5 +883,6 @@ async fn handle_cp(cmd: &CpCommands) -> anyhow::Result<()> {
             }
             Ok(())
         }
+        CpCommands::Volume(volume_cmd) => commands::cp::handle_volume(volume_cmd).await,
     }
 }

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -95,6 +95,9 @@ pub async fn start(
             get(api_container_logs),
         )
         .route("/api/dns/sync", post(api_dns_sync))
+        // Persistence Volume Tier P-2 (2026-04-23)
+        .route("/api/v1/volumes", get(api_volumes))
+        .route("/api/v1/volumes/adopt", post(api_volume_adopt))
         .layer(middleware::from_fn_with_state(
             web_state.clone(),
             auth_middleware,
@@ -1435,6 +1438,230 @@ async fn api_tenant_users_delete(
             Json(json!({ "error": e.to_string() })),
         )
             .into_response(),
+    }
+}
+
+// ============================================================================
+// Volume API (Persistence Volume Tier P-2, 2026-04-23)
+//
+// tenant の永続データを格納する disk 抽象を操作する endpoint 群。
+// 詳細設計: fleetstage repo docs/design/20-persistence-volume-tier.md
+// ============================================================================
+
+/// GET /api/v1/volumes — tenant scoped volume 一覧
+async fn api_volumes(State(state): State<Arc<WebState>>, req: Request) -> impl IntoResponse {
+    let ctx = req.extensions().get::<AuthContext>().unwrap();
+
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    let tenant_id = tenant.id.expect("tenant.id should exist after fetch");
+    match state.app.db.list_volumes_by_tenant(&tenant_id).await {
+        Ok(volumes) => {
+            let items: Vec<Value> = volumes
+                .iter()
+                .map(|v| {
+                    json!({
+                        "slug": v.slug,
+                        "tier": v.tier,
+                        "mount": v.mount,
+                        "size_bytes": v.size_bytes,
+                        "provider": v.provider,
+                        "provider_resource_id": v.provider_resource_id,
+                        "encryption": v.encryption,
+                        "bring_your_own": v.bring_your_own,
+                        "state": v.state,
+                        "created_at": v.created_at.map(|d| d.to_rfc3339()),
+                        "updated_at": v.updated_at.map(|d| d.to_rfc3339()),
+                    })
+                })
+                .collect();
+            (StatusCode::OK, Json(json!({ "volumes": items }))).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/v1/volumes/adopt — 既存 disk を BYO (bring-your-own) で registry 登録
+///
+/// リクエスト body:
+/// ```json
+/// {
+///   "server": "creo-prod",
+///   "slug": "surrealdb-legacy",
+///   "mount": "/var/lib/surrealdb/prod",
+///   "tier": "local-volume"
+/// }
+/// ```
+///
+/// データには一切触れない。fleetstage CP DB に record を作成するだけ。
+async fn api_volume_adopt(State(state): State<Arc<WebState>>, req: Request) -> impl IntoResponse {
+    let ctx = req
+        .extensions()
+        .get::<AuthContext>()
+        .expect("AuthContext missing")
+        .clone();
+
+    // 認可チェック: owner/admin のみ (インフラ操作)
+    if !ctx.can_operate() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Insufficient permissions" })),
+        )
+            .into_response();
+    }
+
+    let body = match axum::body::to_bytes(req.into_body(), 1024 * 16).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("invalid body: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+    let payload: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("invalid JSON: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+
+    let server_slug = match payload["server"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`server` required" })),
+            )
+                .into_response();
+        }
+    };
+    let slug = match payload["slug"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`slug` required" })),
+            )
+                .into_response();
+        }
+    };
+    let mount = match payload["mount"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`mount` required" })),
+            )
+                .into_response();
+        }
+    };
+    let tier = payload["tier"]
+        .as_str()
+        .unwrap_or(fleetflow_controlplane::model::volume_tier::LOCAL_VOLUME)
+        .to_string();
+
+    // tenant 解決
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let tenant_id = tenant.id.expect("tenant.id should exist after fetch");
+
+    // server 解決 (tenant 配下の server であることを確認)
+    let server = match state.app.db.get_server_by_slug(&server_slug).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": format!("Server `{}` not found", server_slug) })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    if server.tenant != tenant_id {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Server does not belong to this tenant" })),
+        )
+            .into_response();
+    }
+    let server_id = server.id.expect("server.id should exist after fetch");
+
+    match state
+        .app
+        .db
+        .adopt_volume(&tenant_id, &server_id, &slug, &mount, &tier)
+        .await
+    {
+        Ok(volume) => (
+            StatusCode::CREATED,
+            Json(json!({
+                "volume": {
+                    "slug": volume.slug,
+                    "tier": volume.tier,
+                    "mount": volume.mount,
+                    "bring_your_own": volume.bring_your_own,
+                    "state": volume.state,
+                    "server_slug": server_slug,
+                }
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            let msg = e.to_string();
+            let status = if msg.contains("invalid volume tier") || msg.contains("invalid") {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, Json(json!({ "error": msg }))).into_response()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Persistence Volume Tier の操作手段を 3 層で実装 (P-1 #139 の schema + CRUD に載せる形):

1. **Unison handler** \`handlers/volume.rs\` (list / adopt methods)
2. **REST endpoints** \`GET /api/v1/volumes\` / \`POST /api/v1/volumes/adopt\` (auth_middleware + can_operate())
3. **CLI** \`fleet cp volume list\` / \`fleet cp volume adopt\`

## 使い方

\`\`\`
fleet cp volume adopt \\
  --slug surrealdb-legacy \\
  --server creo-prod \\
  --mount /var/lib/surrealdb/prod \\
  --tier local-volume
\`\`\`

→ Creo の既存 SurrealDB データに **1 byte も触れず** fleetstage registry 登録。

## 安全策

- tenant scope の確認: CLI は credentials.json の tenant_slug、handler は payload → server が tenant 配下か検証
- adopt_volume は data-in-place、何も動かさない (P-1 で固定されている)
- REST は can_operate() 必須 (owner/admin のみ)

## Test plan

- [x] \`cargo build --workspace\` green
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] \`cargo test -p fleetflow-controlplane --lib volume\` → **9 tests pass** (P-1 の schema ⇔ const drift 防止テスト含む)
- [x] \`cargo fmt --all\` 適用済
- [ ] merge + fleetstage VPS redeploy 後、\`fleet cp volume adopt\` E2E 確認

## 次

- P-3: Creo Memories Phase B 実施 (ops)
- P-4: D2 attached-disk Sakura API (L)
- P-5: Backup scheduler (M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)