### PR TITLE
feat(build): Build Tier v1 MVP — build_job schema + CRUD + handler + REST + CLI + agent

### DIFF
--- a/crates/fleet-agent/Cargo.toml
+++ b/crates/fleet-agent/Cargo.toml
@@ -37,6 +37,9 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Docker API
 bollard.workspace = true
 
+# Build Tier
+fleetflow-build.workspace = true
+
 # CLI
 clap.workspace = true
 

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -1,5 +1,7 @@
 //! Agent コアループ — CP 接続 + コマンド受信 + ハートビート
 
+use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -137,6 +139,9 @@ async fn command_loop(
                 };
                 channel.send_response(msg.id, "status", response).await?;
             }
+            "build" => {
+                handle_build(&channel, msg.id, &payload).await?;
+            }
             "ping" => {
                 channel
                     .send_response(msg.id, "ping", json!({ "pong": true }))
@@ -217,6 +222,199 @@ async fn handle_deploy(
     // チャネル送信エラーのみ伝播（ネットワーク断）
     channel
         .send_response(request_id, "deploy", response)
+        .await?;
+
+    Ok(())
+}
+
+/// Build Tier v1 — "build" コマンドハンドラ
+///
+/// payload: { git_url, git_ref, dockerfile, image, job_id }
+///
+/// 1. work dir 作成 (/var/lib/fleet-agent/builds/<job-id>/)
+/// 2. git clone
+/// 3. fleetflow_build::ImageBuilder で docker build
+/// 4. docker push (shellout)
+/// 5. 完了 event を CP に送信
+async fn handle_build(
+    channel: &UnisonChannel,
+    request_id: u64,
+    payload: &serde_json::Value,
+) -> Result<()> {
+    let git_url = payload["git_url"].as_str().unwrap_or_default();
+    let git_ref = payload["git_ref"].as_str().unwrap_or("main");
+    let dockerfile = payload["dockerfile"].as_str().unwrap_or("Dockerfile");
+    let image = payload["image"].as_str().unwrap_or_default();
+    let job_id = payload["job_id"].as_str().unwrap_or("unknown");
+
+    if git_url.is_empty() {
+        channel
+            .send_response(
+                request_id,
+                "build",
+                json!({ "status": "failed", "error": "git_url required" }),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    // work dir: /var/lib/fleet-agent/builds/<job-id>/
+    let work_dir = std::path::PathBuf::from(format!("/var/lib/fleet-agent/builds/{}", job_id));
+    if let Err(e) = std::fs::create_dir_all(&work_dir) {
+        channel
+            .send_response(
+                request_id,
+                "build",
+                json!({ "status": "failed", "error": format!("work dir 作成失敗: {}", e) }),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    // git clone
+    info!(git_url, git_ref, job_id, "git clone 開始");
+    let clone_result = std::process::Command::new("git")
+        .args(["clone", "--depth=1", "--branch", git_ref, git_url, "."])
+        .current_dir(&work_dir)
+        .status();
+
+    match clone_result {
+        Ok(status) if status.success() => {
+            info!(job_id, "git clone 完了");
+        }
+        Ok(status) => {
+            let err = format!("git clone failed (exit code: {:?})", status.code());
+            error!(job_id, error = %err, "git clone 失敗");
+            channel
+                .send_response(
+                    request_id,
+                    "build",
+                    json!({ "status": "failed", "error": err }),
+                )
+                .await?;
+            return Ok(());
+        }
+        Err(e) => {
+            let err = format!("git clone shellout 失敗: {}", e);
+            error!(job_id, error = %err);
+            channel
+                .send_response(
+                    request_id,
+                    "build",
+                    json!({ "status": "failed", "error": err }),
+                )
+                .await?;
+            return Ok(());
+        }
+    }
+
+    // docker build via fleetflow-build ImageBuilder
+    let start_ms = std::time::Instant::now();
+    let docker = match bollard::Docker::connect_with_local_defaults() {
+        Ok(d) => d,
+        Err(e) => {
+            let err = format!("docker daemon 接続失敗: {}", e);
+            error!(job_id, error = %err);
+            channel
+                .send_response(
+                    request_id,
+                    "build",
+                    json!({ "status": "failed", "error": err }),
+                )
+                .await?;
+            return Ok(());
+        }
+    };
+
+    let builder = fleetflow_build::ImageBuilder::new(docker);
+    let context_path = work_dir.clone();
+    let dockerfile_path = work_dir.join(dockerfile);
+
+    info!(job_id, image, "docker build 開始");
+    let build_result = builder
+        .build_image_from_path(
+            &context_path,
+            &dockerfile_path,
+            image,
+            HashMap::new(),
+            None,
+            false,
+            Some("linux/amd64"),
+        )
+        .await;
+
+    let duration_ms = start_ms.elapsed().as_millis();
+
+    match build_result {
+        Ok(()) => {
+            info!(job_id, image, duration_ms, "docker build 成功");
+        }
+        Err(e) => {
+            let err = format!("docker build 失敗: {}", e);
+            error!(job_id, error = %err);
+            channel
+                .send_response(
+                    request_id,
+                    "build",
+                    json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
+                )
+                .await?;
+            return Ok(());
+        }
+    }
+
+    // docker push (shellout)
+    if !image.is_empty() {
+        info!(job_id, image, "docker push 開始");
+        let push_result = std::process::Command::new("docker")
+            .args(["push", image])
+            .status();
+
+        match push_result {
+            Ok(status) if status.success() => {
+                info!(job_id, image, "docker push 完了");
+            }
+            Ok(status) => {
+                let err = format!("docker push failed (exit code: {:?})", status.code());
+                error!(job_id, error = %err);
+                channel
+                    .send_response(
+                        request_id,
+                        "build",
+                        json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
+                    )
+                    .await?;
+                return Ok(());
+            }
+            Err(e) => {
+                let err = format!("docker push shellout 失敗: {}", e);
+                error!(job_id, error = %err);
+                channel
+                    .send_response(
+                        request_id,
+                        "build",
+                        json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
+                    )
+                    .await?;
+                return Ok(());
+            }
+        }
+    }
+
+    // 成功
+    let duration_secs = duration_ms / 1000;
+    info!(job_id, image, duration_secs, "build 完了");
+    channel
+        .send_response(
+            request_id,
+            "build",
+            json!({
+                "status": "success",
+                "image": image,
+                "duration_ms": duration_ms,
+                "duration_seconds": duration_secs,
+            }),
+        )
         .await?;
 
     Ok(())

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -1,7 +1,6 @@
 //! Agent コアループ — CP 接続 + コマンド受信 + ハートビート
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -1121,6 +1121,95 @@ impl Database {
         let snapshots: Vec<VolumeSnapshot> = result.take(0)?;
         Ok(snapshots)
     }
+
+    // ─────────────────────────────────────────
+    // BuildJob CRUD (Build Tier v1 MVP, 2026-04-23)
+    //
+    // 詳細設計: fleetstage repo docs/design/30-build-tier.md
+    // ─────────────────────────────────────────
+
+    /// BuildJob を新規作成 (state=queued でエンキュー)。
+    ///
+    /// `kind` と `state` は model の定数に従う (build_job_kind / build_job_state モジュール参照)。
+    pub async fn create_build_job(&self, job: &BuildJob) -> Result<BuildJob> {
+        if !build_job_kind::is_valid(&job.kind) {
+            anyhow::bail!("invalid build job kind: {}", job.kind);
+        }
+        if !build_job_state::is_valid(&job.state) {
+            anyhow::bail!("invalid build job state: {}", job.state);
+        }
+        // source / target は nested object のため flat scalar bind で展開する
+        // (surrealdb の serde_json::Value bind は壊れる — project_surrealdb_bind_pitfall)
+        let mut result = self
+            .db
+            .query(
+                "CREATE build_job CONTENT { \
+                    tenant: $tenant, project: $project, \
+                    kind: $kind, \
+                    source: { git_url: $git_url, git_ref: $git_ref, dockerfile: $dockerfile }, \
+                    target: { image: $image, registry_secret: $registry_secret }, \
+                    state: $state, server: $server, logs_url: $logs_url, \
+                    started_at: $started_at, finished_at: $finished_at, \
+                    duration_seconds: $duration_seconds \
+                }",
+            )
+            .bind(("tenant", job.tenant.clone()))
+            .bind(("project", job.project.clone()))
+            .bind(("kind", job.kind.clone()))
+            .bind(("git_url", job.source.git_url.clone()))
+            .bind(("git_ref", job.source.git_ref.clone()))
+            .bind(("dockerfile", job.source.dockerfile.clone()))
+            .bind(("image", job.target.image.clone()))
+            .bind(("registry_secret", job.target.registry_secret.clone()))
+            .bind(("state", job.state.clone()))
+            .bind(("server", job.server.clone()))
+            .bind(("logs_url", job.logs_url.clone()))
+            .bind(("started_at", job.started_at))
+            .bind(("finished_at", job.finished_at))
+            .bind(("duration_seconds", job.duration_seconds))
+            .await
+            .context("BuildJob 作成失敗")?;
+        let created: Option<BuildJob> = result.take(0)?;
+        created.context("BuildJob 作成結果が空")
+    }
+
+    /// BuildJob を ID で取得。
+    pub async fn get_build_job_by_id(&self, job_id: &RecordId) -> Result<Option<BuildJob>> {
+        let mut result = self
+            .db
+            .query("SELECT * FROM build_job WHERE id = $id LIMIT 1")
+            .bind(("id", job_id.clone()))
+            .await
+            .context("BuildJob 取得失敗")?;
+        let jobs: Vec<BuildJob> = result.take(0)?;
+        Ok(jobs.into_iter().next())
+    }
+
+    /// テナント配下の BuildJob 一覧を取得 (submitted_at DESC)。
+    pub async fn list_build_jobs_by_tenant(&self, tenant_id: &RecordId) -> Result<Vec<BuildJob>> {
+        let mut result = self
+            .db
+            .query("SELECT * FROM build_job WHERE tenant = $tenant ORDER BY submitted_at DESC")
+            .bind(("tenant", tenant_id.clone()))
+            .await
+            .context("BuildJob 一覧取得失敗")?;
+        let jobs: Vec<BuildJob> = result.take(0)?;
+        Ok(jobs)
+    }
+
+    /// BuildJob の state を更新。invalid state は拒否。
+    pub async fn update_build_job_state(&self, job_id: &RecordId, new_state: &str) -> Result<()> {
+        if !build_job_state::is_valid(new_state) {
+            anyhow::bail!("invalid build job state: {}", new_state);
+        }
+        self.db
+            .query("UPDATE $id SET state = $state")
+            .bind(("id", job_id.clone()))
+            .bind(("state", new_state.to_string()))
+            .await
+            .context("BuildJob state 更新失敗")?;
+        Ok(())
+    }
 }
 
 /// SurrealDB schema definition.
@@ -1359,6 +1448,30 @@ DEFINE FIELD IF NOT EXISTS size_bytes ON volume_snapshot TYPE option<int>;
 DEFINE FIELD IF NOT EXISTS taken_at ON volume_snapshot TYPE option<datetime> DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS retention_until ON volume_snapshot TYPE option<datetime>;
 DEFINE INDEX IF NOT EXISTS idx_volume_snapshot_volume ON volume_snapshot FIELDS volume;
+
+-- CP-011: BuildJob (Build Tier v1 MVP, 2026-04-23)
+-- 詳細設計: fleetstage repo docs/design/30-build-tier.md
+DEFINE TABLE IF NOT EXISTS build_job SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS tenant ON build_job TYPE record<tenant>;
+DEFINE FIELD IF NOT EXISTS project ON build_job TYPE option<record<project>>;
+DEFINE FIELD IF NOT EXISTS kind ON build_job TYPE string
+  ASSERT $value IN ["docker-image", "cargo-binary", "static-site"];
+DEFINE FIELD IF NOT EXISTS source ON build_job TYPE object;
+DEFINE FIELD IF NOT EXISTS source.git_url ON build_job TYPE string;
+DEFINE FIELD IF NOT EXISTS source.git_ref ON build_job TYPE string DEFAULT 'main';
+DEFINE FIELD IF NOT EXISTS source.dockerfile ON build_job TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS target ON build_job TYPE object;
+DEFINE FIELD IF NOT EXISTS target.image ON build_job TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS target.registry_secret ON build_job TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS state ON build_job TYPE string
+  ASSERT $value IN ["queued", "assigned", "cloning", "building", "pushing", "success", "failed", "cancelled"];
+DEFINE FIELD IF NOT EXISTS server ON build_job TYPE option<record<server>>;
+DEFINE FIELD IF NOT EXISTS logs_url ON build_job TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS submitted_at ON build_job TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS started_at ON build_job TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS finished_at ON build_job TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS duration_seconds ON build_job TYPE option<int>;
+DEFINE INDEX IF NOT EXISTS idx_build_job_tenant_state ON build_job FIELDS tenant, state;
 "#;
 
 #[cfg(test)]
@@ -2415,5 +2528,194 @@ mod tests {
             .await
             .expect_err("invalid kind");
         assert!(err.to_string().contains("invalid volume snapshot kind"));
+    }
+
+    // ─────────────────────────────────────────
+    // BuildJob tests (Build Tier v1 MVP, 2026-04-23)
+    // ─────────────────────────────────────────
+
+    fn make_build_job(tenant_id: RecordId) -> BuildJob {
+        BuildJob {
+            id: None,
+            tenant: tenant_id,
+            project: None,
+            kind: build_job_kind::DOCKER_IMAGE.to_string(),
+            source: BuildSource {
+                git_url: "https://github.com/chronista-club/fleetflow".to_string(),
+                git_ref: "main".to_string(),
+                dockerfile: Some("infra/Dockerfile.fleetflowd".to_string()),
+            },
+            target: BuildTarget {
+                image: Some("ghcr.io/chronista-club/fleetflowd:test".to_string()),
+                registry_secret: None,
+            },
+            state: build_job_state::QUEUED.to_string(),
+            server: None,
+            logs_url: None,
+            submitted_at: None,
+            started_at: None,
+            finished_at: None,
+            duration_seconds: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn build_job_state_constants_match_schema_assertions() {
+        // schema の ASSERT $value IN [...] 列と build_job_state::ALL が一致することを保証する
+        // (リネーム・追加時に片方だけ更新して drift する事故を予防)
+        let expected = [
+            "queued",
+            "assigned",
+            "cloning",
+            "building",
+            "pushing",
+            "success",
+            "failed",
+            "cancelled",
+        ];
+        assert_eq!(build_job_state::ALL, expected);
+        for s in &expected {
+            assert!(build_job_state::is_valid(s));
+        }
+        assert!(!build_job_state::is_valid("unknown-state"));
+    }
+
+    #[tokio::test]
+    async fn build_job_kind_constants_match_schema_assertions() {
+        let expected = ["docker-image", "cargo-binary", "static-site"];
+        assert_eq!(build_job_kind::ALL, expected);
+        for k in &expected {
+            assert!(build_job_kind::is_valid(k));
+        }
+        assert!(!build_job_kind::is_valid("unknown-kind"));
+    }
+
+    #[tokio::test]
+    async fn create_build_job_succeeds_minimum_fields() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, _) = seed_tenant_and_server(&db).await;
+
+        let job = make_build_job(tenant_id);
+        let created = db.create_build_job(&job).await.unwrap();
+
+        assert!(created.id.is_some());
+        assert_eq!(created.kind, "docker-image");
+        assert_eq!(created.state, "queued");
+        assert_eq!(
+            created.source.git_url,
+            "https://github.com/chronista-club/fleetflow"
+        );
+        assert_eq!(created.source.git_ref, "main");
+        assert_eq!(
+            created.target.image.as_deref(),
+            Some("ghcr.io/chronista-club/fleetflowd:test")
+        );
+    }
+
+    #[tokio::test]
+    async fn list_build_jobs_returns_tenant_scoped() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, _) = seed_tenant_and_server(&db).await;
+
+        // 別テナントを作成して別 job を登録
+        let other_tenant = db
+            .create_tenant(&Tenant {
+                id: None,
+                slug: "other-tenant".into(),
+                name: "Other Tenant".into(),
+                auth0_org_id: None,
+                plan: "self-hosted".into(),
+                dns_provider: None,
+                dns_domain: None,
+                dns_zone_id: None,
+                dns_api_token_encrypted: None,
+                placement_policy: None,
+                created_at: None,
+                updated_at: None,
+            })
+            .await
+            .unwrap();
+        let other_tenant_id = other_tenant.id.unwrap();
+
+        db.create_build_job(&make_build_job(tenant_id.clone()))
+            .await
+            .unwrap();
+        db.create_build_job(&make_build_job(tenant_id.clone()))
+            .await
+            .unwrap();
+        db.create_build_job(&make_build_job(other_tenant_id))
+            .await
+            .unwrap();
+
+        let jobs = db.list_build_jobs_by_tenant(&tenant_id).await.unwrap();
+        assert_eq!(jobs.len(), 2, "テナントスコープで 2 件のみ取得できるべき");
+    }
+
+    #[tokio::test]
+    async fn update_build_job_state_transitions_through_lifecycle() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, _) = seed_tenant_and_server(&db).await;
+
+        let job = db
+            .create_build_job(&make_build_job(tenant_id))
+            .await
+            .unwrap();
+        let job_id = job.id.unwrap();
+
+        db.update_build_job_state(&job_id, build_job_state::ASSIGNED)
+            .await
+            .unwrap();
+        db.update_build_job_state(&job_id, build_job_state::CLONING)
+            .await
+            .unwrap();
+        db.update_build_job_state(&job_id, build_job_state::BUILDING)
+            .await
+            .unwrap();
+        db.update_build_job_state(&job_id, build_job_state::PUSHING)
+            .await
+            .unwrap();
+        db.update_build_job_state(&job_id, build_job_state::SUCCESS)
+            .await
+            .unwrap();
+
+        let updated = db
+            .get_build_job_by_id(&job_id)
+            .await
+            .unwrap()
+            .expect("job 存在");
+        assert_eq!(updated.state, "success");
+    }
+
+    #[tokio::test]
+    async fn create_build_job_rejects_invalid_kind() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, _) = seed_tenant_and_server(&db).await;
+
+        let mut bad = make_build_job(tenant_id);
+        bad.kind = "invalid-kind".to_string();
+
+        let err = db
+            .create_build_job(&bad)
+            .await
+            .expect_err("invalid kind は拒否されるべき");
+        assert!(err.to_string().contains("invalid build job kind"));
+    }
+
+    #[tokio::test]
+    async fn update_build_job_state_rejects_invalid_state() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, _) = seed_tenant_and_server(&db).await;
+
+        let job = db
+            .create_build_job(&make_build_job(tenant_id))
+            .await
+            .unwrap();
+        let job_id = job.id.unwrap();
+
+        let err = db
+            .update_build_job_state(&job_id, "unknown-state")
+            .await
+            .expect_err("invalid state は拒否されるべき");
+        assert!(err.to_string().contains("invalid build job state"));
     }
 }

--- a/crates/fleetflow-controlplane/src/handlers/build.rs
+++ b/crates/fleetflow-controlplane/src/handlers/build.rs
@@ -240,7 +240,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
 
                             // RecordId 構築
                             let record_id =
-                                surrealdb::types::RecordId::from_table_key("build_job", job_id_str);
+                                surrealdb::types::RecordId::new("build_job", job_id_str);
 
                             match state.db.get_build_job_by_id(&record_id).await {
                                 Ok(Some(job)) => {
@@ -327,7 +327,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             let tenant_id = tenant.id.expect("tenant.id");
 
                             let record_id =
-                                surrealdb::types::RecordId::from_table_key("build_job", job_id_str);
+                                surrealdb::types::RecordId::new("build_job", job_id_str);
 
                             // job の存在と tenant scope を確認してから cancel
                             match state.db.get_build_job_by_id(&record_id).await {

--- a/crates/fleetflow-controlplane/src/handlers/build.rs
+++ b/crates/fleetflow-controlplane/src/handlers/build.rs
@@ -1,0 +1,421 @@
+//! Build channel handler (Build Tier v1 MVP, 2026-04-23)
+//!
+//! `fleet cp build <subcommand>` からの Unison Protocol リクエストを処理する。
+//! build_job の submit / list / get / cancel を提供する。
+//!
+//! 詳細設計: fleetstage repo `docs/design/30-build-tier.md`
+
+use std::sync::Arc;
+
+use serde_json::json;
+use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
+
+use crate::model::{BuildJob, BuildSource, BuildTarget, build_job_kind, build_job_state};
+use crate::server::AppState;
+
+pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
+    server
+        .register_channel("build", move |_ctx, stream| {
+            let state = state.clone();
+            Box::pin(async move {
+                let channel = UnisonChannel::new(stream);
+                loop {
+                    let msg = channel.recv().await?;
+                    let payload = msg.payload_as_value()?;
+
+                    match msg.method.as_str() {
+                        "submit" => {
+                            let tenant_slug =
+                                payload["tenant_slug"].as_str().unwrap_or_default();
+
+                            // tenant 解決
+                            let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
+                                Ok(Some(t)) => t,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "submit",
+                                            json!({ "error": "tenant not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "tenant lookup 失敗 (build.submit)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "submit",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            let tenant_id = tenant.id.expect("tenant.id");
+
+                            let git_url = payload["git_url"].as_str().unwrap_or_default();
+                            let git_ref = payload["git_ref"]
+                                .as_str()
+                                .unwrap_or("main")
+                                .to_string();
+                            let kind = payload["kind"]
+                                .as_str()
+                                .unwrap_or(build_job_kind::DOCKER_IMAGE);
+
+                            if git_url.is_empty() {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "submit",
+                                        json!({ "error": "`git_url` required" }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+
+                            if !build_job_kind::is_valid(kind) {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "submit",
+                                        json!({ "error": format!("invalid kind: {}", kind) }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+
+                            let job = BuildJob {
+                                id: None,
+                                tenant: tenant_id,
+                                project: None,
+                                kind: kind.to_string(),
+                                source: BuildSource {
+                                    git_url: git_url.to_string(),
+                                    git_ref,
+                                    dockerfile: payload["dockerfile"]
+                                        .as_str()
+                                        .map(|s| s.to_string()),
+                                },
+                                target: BuildTarget {
+                                    image: payload["image"].as_str().map(|s| s.to_string()),
+                                    registry_secret: payload["registry_secret"]
+                                        .as_str()
+                                        .map(|s| s.to_string()),
+                                },
+                                state: build_job_state::QUEUED.to_string(),
+                                server: None,
+                                logs_url: None,
+                                submitted_at: None,
+                                started_at: None,
+                                finished_at: None,
+                                duration_seconds: None,
+                            };
+
+                            match state.db.create_build_job(&job).await {
+                                Ok(created) => {
+                                    info!(
+                                        job_id = ?created.id,
+                                        kind = %created.kind,
+                                        git_url = %created.source.git_url,
+                                        "build job submitted (queued)"
+                                    );
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "submit",
+                                            json!({ "build_job": created }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "build.submit 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "submit",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        "list" => {
+                            let tenant_slug =
+                                payload["tenant_slug"].as_str().unwrap_or_default();
+
+                            let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
+                                Ok(Some(t)) => t,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "error": "tenant not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "tenant lookup 失敗 (build.list)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            let tenant_id = tenant.id.expect("tenant.id");
+
+                            match state.db.list_build_jobs_by_tenant(&tenant_id).await {
+                                Ok(jobs) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "build_jobs": jobs }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "build.list 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "list",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        "get" => {
+                            let tenant_slug =
+                                payload["tenant_slug"].as_str().unwrap_or_default();
+                            let job_id_str = payload["job_id"].as_str().unwrap_or_default();
+
+                            if job_id_str.is_empty() {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "get",
+                                        json!({ "error": "`job_id` required" }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+
+                            // tenant scope 検証
+                            let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
+                                Ok(Some(t)) => t,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "get",
+                                            json!({ "error": "tenant not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "tenant lookup 失敗 (build.get)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "get",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            let tenant_id = tenant.id.expect("tenant.id");
+
+                            // RecordId 構築
+                            let record_id =
+                                surrealdb::types::RecordId::from_table_key("build_job", job_id_str);
+
+                            match state.db.get_build_job_by_id(&record_id).await {
+                                Ok(Some(job)) => {
+                                    // tenant scope チェック
+                                    if job.tenant != tenant_id {
+                                        channel
+                                            .send_response(
+                                                msg.id,
+                                                "get",
+                                                json!({ "error": "job does not belong to this tenant" }),
+                                            )
+                                            .await?;
+                                        continue;
+                                    }
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "get",
+                                            json!({ "build_job": job }),
+                                        )
+                                        .await?;
+                                }
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "get",
+                                            json!({ "error": "build job not found" }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "build.get 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "get",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        "cancel" => {
+                            let tenant_slug =
+                                payload["tenant_slug"].as_str().unwrap_or_default();
+                            let job_id_str = payload["job_id"].as_str().unwrap_or_default();
+
+                            if job_id_str.is_empty() {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "cancel",
+                                        json!({ "error": "`job_id` required" }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+
+                            let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
+                                Ok(Some(t)) => t,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "cancel",
+                                            json!({ "error": "tenant not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "tenant lookup 失敗 (build.cancel)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "cancel",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            let tenant_id = tenant.id.expect("tenant.id");
+
+                            let record_id =
+                                surrealdb::types::RecordId::from_table_key("build_job", job_id_str);
+
+                            // job の存在と tenant scope を確認してから cancel
+                            match state.db.get_build_job_by_id(&record_id).await {
+                                Ok(Some(job)) => {
+                                    if job.tenant != tenant_id {
+                                        channel
+                                            .send_response(
+                                                msg.id,
+                                                "cancel",
+                                                json!({ "error": "job does not belong to this tenant" }),
+                                            )
+                                            .await?;
+                                        continue;
+                                    }
+                                    // queued / assigned のみ cancel 可能 (running 中はエラー)
+                                    if job.state == build_job_state::SUCCESS
+                                        || job.state == build_job_state::FAILED
+                                        || job.state == build_job_state::CANCELLED
+                                    {
+                                        channel
+                                            .send_response(
+                                                msg.id,
+                                                "cancel",
+                                                json!({ "error": format!("cannot cancel job in state: {}", job.state) }),
+                                            )
+                                            .await?;
+                                        continue;
+                                    }
+                                    match state
+                                        .db
+                                        .update_build_job_state(&record_id, build_job_state::CANCELLED)
+                                        .await
+                                    {
+                                        Ok(()) => {
+                                            info!(job_id = %job_id_str, "build job cancelled");
+                                            channel
+                                                .send_response(
+                                                    msg.id,
+                                                    "cancel",
+                                                    json!({ "status": "cancelled" }),
+                                                )
+                                                .await?;
+                                        }
+                                        Err(e) => {
+                                            error!(error = %e, "build.cancel state update 失敗");
+                                            channel
+                                                .send_response(
+                                                    msg.id,
+                                                    "cancel",
+                                                    json!({ "error": e.to_string() }),
+                                                )
+                                                .await?;
+                                        }
+                                    }
+                                }
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "cancel",
+                                            json!({ "error": "build job not found" }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "build.cancel lookup 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "cancel",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        other => {
+                            channel
+                                .send_response(
+                                    msg.id,
+                                    other,
+                                    json!({ "error": format!("unknown method: {}", other) }),
+                                )
+                                .await?;
+                        }
+                    }
+                }
+            })
+        })
+        .await;
+}

--- a/crates/fleetflow-controlplane/src/handlers/mod.rs
+++ b/crates/fleetflow-controlplane/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod build;
 pub mod container;
 pub mod cost;
 pub mod deploy;
@@ -30,4 +31,5 @@ pub async fn register_all(server: &ProtocolServer, state: Arc<AppState>) {
     deploy::register(server, state.clone()).await;
     agent::register(server, state.clone()).await;
     volume::register(server, state.clone()).await;
+    build::register(server, state.clone()).await;
 }

--- a/crates/fleetflow-controlplane/src/lib.rs
+++ b/crates/fleetflow-controlplane/src/lib.rs
@@ -7,3 +7,10 @@ pub mod log_router;
 pub mod model;
 pub mod server;
 pub mod server_provider;
+
+/// SurrealDB RecordId を re-export。
+///
+/// fleetflowd (REST handler) から build_job 等の id lookup を行う時に
+/// `fleetflow_controlplane::RecordId::new("table", key)` の形で使う。
+/// Controlplane が唯一の SurrealDB 依存点なので、外部 crate は本 alias 経由で参照する。
+pub use surrealdb::types::RecordId;

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -656,3 +656,99 @@ pub struct VolumeSnapshot {
     /// 保持期限、越えたら cleanup 対象
     pub retention_until: Option<DateTime<Utc>>,
 }
+
+// ─────────────────────────────────────────────
+// CP-011: BuildJob (Build Tier v1 MVP)
+//
+// tenant の build ジョブを記録する。Build Tier B1 (ephemeral-vps-shared)。
+// 詳細設計: fleetstage repo docs/design/30-build-tier.md
+// ─────────────────────────────────────────────
+
+/// Build ジョブの lifecycle 状態。
+pub mod build_job_state {
+    /// キューに積まれた (pending)
+    pub const QUEUED: &str = "queued";
+    /// Build VPS に割り当て済み
+    pub const ASSIGNED: &str = "assigned";
+    /// git clone 中
+    pub const CLONING: &str = "cloning";
+    /// docker build 実行中
+    pub const BUILDING: &str = "building";
+    /// registry push 中
+    pub const PUSHING: &str = "pushing";
+    /// 成功完了
+    pub const SUCCESS: &str = "success";
+    /// 失敗
+    pub const FAILED: &str = "failed";
+    /// キャンセル
+    pub const CANCELLED: &str = "cancelled";
+
+    pub const ALL: &[&str] = &[
+        QUEUED, ASSIGNED, CLONING, BUILDING, PUSHING, SUCCESS, FAILED, CANCELLED,
+    ];
+
+    pub fn is_valid(s: &str) -> bool {
+        ALL.contains(&s)
+    }
+}
+
+/// Build ジョブの種別。
+pub mod build_job_kind {
+    /// Docker イメージ build
+    pub const DOCKER_IMAGE: &str = "docker-image";
+    /// Cargo バイナリ build
+    pub const CARGO_BINARY: &str = "cargo-binary";
+    /// 静的サイト build
+    pub const STATIC_SITE: &str = "static-site";
+
+    pub const ALL: &[&str] = &[DOCKER_IMAGE, CARGO_BINARY, STATIC_SITE];
+
+    pub fn is_valid(s: &str) -> bool {
+        ALL.contains(&s)
+    }
+}
+
+/// Build のソース (git リポジトリ + dockerfile パス)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct BuildSource {
+    pub git_url: String,
+    /// ブランチ / タグ / SHA。スキーマフィールド名 "git_ref" でそのまま格納。
+    pub git_ref: String,
+    pub dockerfile: Option<String>,
+}
+
+/// Build のターゲット (イメージタグ + registry 認証情報)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct BuildTarget {
+    pub image: Option<String>,
+    pub registry_secret: Option<String>,
+}
+
+/// Build ジョブ — tenant の build リクエストを記録する。
+///
+/// 1 job = 1 docker build 実行 (またはそれに相当する操作)。
+/// fleet-agent の "build" コマンドで実行される。
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct BuildJob {
+    pub id: Option<RecordId>,
+    pub tenant: RecordId,
+    /// 所属 project (optional)
+    pub project: Option<RecordId>,
+    /// Build 種別: `build_job_kind` モジュールの定数
+    pub kind: String,
+    /// ソース情報 (git repository)
+    pub source: BuildSource,
+    /// ターゲット情報 (image tag 等)
+    pub target: BuildTarget,
+    /// 現在の lifecycle 状態: `build_job_state` モジュールの定数
+    pub state: String,
+    /// 割り当てられた Build VPS の server ID
+    pub server: Option<RecordId>,
+    /// ログの参照先 URL (v1 は polling、logs_url を polling する)
+    pub logs_url: Option<String>,
+    pub submitted_at: Option<DateTime<Utc>>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+    /// 実行時間 (秒)
+    pub duration_seconds: Option<i64>,
+}

--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -9,8 +9,8 @@ use serde_json::json;
 
 use super::cp_client;
 use crate::{
-    CostCommands, DnsCommands, ProjectCommands, RemoteCommands, ServerCommands, TenantCommands,
-    VolumeCommands,
+    BuildCommands, CostCommands, DnsCommands, ProjectCommands, RemoteCommands, ServerCommands,
+    TenantCommands, VolumeCommands,
 };
 
 pub async fn handle_tenant(cmd: &TenantCommands) -> Result<()> {
@@ -812,6 +812,220 @@ pub async fn handle_volume(cmd: &VolumeCommands) -> Result<()> {
                     } else {
                         "no".dimmed().to_string()
                     }
+                );
+            }
+
+            client.disconnect().await.ok();
+        }
+    }
+
+    Ok(())
+}
+
+/// Build Tier コマンド (v1 MVP, 2026-04-23)
+pub async fn handle_build(cmd: &BuildCommands) -> Result<()> {
+    match cmd {
+        BuildCommands::Submit {
+            git,
+            git_ref,
+            dockerfile,
+            image,
+            kind,
+            project: _,
+        } => {
+            let (client, creds) = cp_client::connect().await?;
+
+            println!("{}", "Build Job Submit".bold());
+            println!();
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+            let mut payload = json!({
+                "tenant_slug": tenant_slug,
+                "git_url": git,
+                "git_ref": git_ref,
+                "kind": kind,
+            });
+            if let Some(df) = dockerfile {
+                payload["dockerfile"] = serde_json::Value::String(df.clone());
+            }
+            if let Some(img) = image {
+                payload["image"] = serde_json::Value::String(img.clone());
+            }
+
+            let resp = cp_client::request(&client, "build", "submit", payload).await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+            } else if let Some(job) = resp.get("build_job") {
+                println!("{}", "Submitted".green().bold());
+                println!("  ID:      {}", format!("{:?}", job["id"]).cyan());
+                println!("  Kind:    {}", job["kind"].as_str().unwrap_or("-"));
+                println!(
+                    "  State:   {}",
+                    job["state"].as_str().unwrap_or("-").yellow()
+                );
+                println!(
+                    "  Git URL: {}",
+                    job["source"]["git_url"].as_str().unwrap_or("-").dimmed()
+                );
+                println!(
+                    "  Ref:     {}",
+                    job["source"]["git_ref"].as_str().unwrap_or("-")
+                );
+            }
+
+            client.disconnect().await.ok();
+        }
+        BuildCommands::List => {
+            let (client, creds) = cp_client::connect().await?;
+
+            println!("{}", "Build Job 一覧".bold());
+            println!();
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+            let resp = cp_client::request(
+                &client,
+                "build",
+                "list",
+                json!({ "tenant_slug": tenant_slug }),
+            )
+            .await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+                client.disconnect().await.ok();
+                return Ok(());
+            }
+
+            if let Some(jobs) = resp["build_jobs"].as_array() {
+                if jobs.is_empty() {
+                    println!("{}", "Build Job がありません。".dimmed());
+                } else {
+                    println!(
+                        "{}",
+                        format!(
+                            "{:<36} {:<14} {:<10} {:<40}",
+                            "ID", "KIND", "STATE", "GIT URL"
+                        )
+                        .bold()
+                    );
+                    println!("{}", "─".repeat(104).dimmed());
+                    for j in jobs {
+                        println!(
+                            "{:<36} {:<14} {:<10} {:<40}",
+                            format!("{:?}", j["id"]).cyan(),
+                            j["kind"].as_str().unwrap_or("-"),
+                            j["state"].as_str().unwrap_or("-").yellow(),
+                            j["source"]["git_url"].as_str().unwrap_or("-").dimmed(),
+                        );
+                    }
+                }
+            }
+
+            client.disconnect().await.ok();
+        }
+        BuildCommands::Show { id } => {
+            let (client, creds) = cp_client::connect().await?;
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+            let resp = cp_client::request(
+                &client,
+                "build",
+                "get",
+                json!({ "tenant_slug": tenant_slug, "job_id": id }),
+            )
+            .await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+            } else if let Some(job) = resp.get("build_job") {
+                println!("{}", "Build Job 詳細".bold());
+                println!("  ID:              {}", format!("{:?}", job["id"]).cyan());
+                println!("  Kind:            {}", job["kind"].as_str().unwrap_or("-"));
+                println!(
+                    "  State:           {}",
+                    job["state"].as_str().unwrap_or("-").yellow()
+                );
+                println!(
+                    "  Git URL:         {}",
+                    job["source"]["git_url"].as_str().unwrap_or("-").dimmed()
+                );
+                println!(
+                    "  Ref:             {}",
+                    job["source"]["git_ref"].as_str().unwrap_or("-")
+                );
+                if let Some(df) = job["source"]["dockerfile"].as_str() {
+                    println!("  Dockerfile:      {}", df);
+                }
+                if let Some(img) = job["target"]["image"].as_str() {
+                    println!("  Image:           {}", img);
+                }
+                if let Some(logs) = job["logs_url"].as_str() {
+                    println!("  Logs URL:        {}", logs.dimmed());
+                }
+                if let Some(dur) = job["duration_seconds"].as_i64() {
+                    println!("  Duration:        {}s", dur);
+                }
+            }
+
+            client.disconnect().await.ok();
+        }
+        BuildCommands::Logs { id } => {
+            let (client, creds) = cp_client::connect().await?;
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+            let resp = cp_client::request(
+                &client,
+                "build",
+                "get",
+                json!({ "tenant_slug": tenant_slug, "job_id": id }),
+            )
+            .await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+            } else if let Some(job) = resp.get("build_job") {
+                println!("{}", "Build Logs".bold());
+                println!(
+                    "  State:    {}",
+                    job["state"].as_str().unwrap_or("-").yellow()
+                );
+                if let Some(logs_url) = job["logs_url"].as_str() {
+                    println!("  Logs URL: {}", logs_url.dimmed());
+                    println!();
+                    println!(
+                        "{}",
+                        "v1: logs_url を polling して取得してください。".dimmed()
+                    );
+                } else {
+                    println!(
+                        "  {}",
+                        "ログ URL はまだ利用できません (build 開始後に設定されます)。".dimmed()
+                    );
+                }
+            }
+
+            client.disconnect().await.ok();
+        }
+        BuildCommands::Cancel { id } => {
+            let (client, creds) = cp_client::connect().await?;
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+            let resp = cp_client::request(
+                &client,
+                "build",
+                "cancel",
+                json!({ "tenant_slug": tenant_slug, "job_id": id }),
+            )
+            .await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+            } else {
+                println!(
+                    "{} Build Job {} をキャンセルしました。",
+                    "Cancelled.".green().bold(),
+                    id.cyan()
                 );
             }
 

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -281,6 +281,9 @@ enum CpCommands {
     /// Persistence Volume 管理 (Disk Tier、BYO 登録ほか)
     #[command(subcommand)]
     Volume(VolumeCommands),
+    /// Build Tier — CP 経由の docker image / cargo binary などの build ジョブ管理
+    #[command(subcommand)]
+    Build(BuildCommands),
 }
 
 /// デーモン管理のサブコマンド
@@ -514,6 +517,52 @@ pub enum VolumeCommands {
         /// Disk Tier (local-volume 固定推奨、attached-disk 等は P-4 以降)
         #[arg(long, default_value = "local-volume")]
         tier: String,
+    },
+}
+
+/// Build Tier コマンド (v1 MVP, 2026-04-23)
+///
+/// CP 経由でリモート build ジョブを管理する。
+/// 詳細: fleetstage repo docs/design/30-build-tier.md
+#[derive(Subcommand)]
+pub enum BuildCommands {
+    /// Build ジョブを submit (state=queued でエンキュー)
+    Submit {
+        /// Git リポジトリ URL
+        #[arg(long)]
+        git: String,
+        /// ブランチ / タグ / SHA (default: main)
+        #[arg(long, default_value = "main")]
+        git_ref: String,
+        /// Dockerfile のパス (リポジトリルートからの相対パス)
+        #[arg(long)]
+        dockerfile: Option<String>,
+        /// ビルドして push する image tag (例: ghcr.io/owner/name:tag)
+        #[arg(long)]
+        image: Option<String>,
+        /// Build 種別 (default: docker-image)
+        #[arg(long, default_value = "docker-image")]
+        kind: String,
+        /// 所属 project slug (optional)
+        #[arg(long)]
+        project: Option<String>,
+    },
+    /// テナント配下の build job 一覧
+    List,
+    /// build job 詳細表示
+    Show {
+        /// Job ID
+        id: String,
+    },
+    /// build ログ参照 (v1: logs_url polling)
+    Logs {
+        /// Job ID
+        id: String,
+    },
+    /// build job をキャンセル
+    Cancel {
+        /// Job ID
+        id: String,
     },
 }
 
@@ -884,5 +933,6 @@ async fn handle_cp(cmd: &CpCommands) -> anyhow::Result<()> {
             Ok(())
         }
         CpCommands::Volume(volume_cmd) => commands::cp::handle_volume(volume_cmd).await,
+        CpCommands::Build(build_cmd) => commands::cp::handle_build(build_cmd).await,
     }
 }

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -98,6 +98,11 @@ pub async fn start(
         // Persistence Volume Tier P-2 (2026-04-23)
         .route("/api/v1/volumes", get(api_volumes))
         .route("/api/v1/volumes/adopt", post(api_volume_adopt))
+        // Build Tier v1 MVP (2026-04-23)
+        .route("/api/v1/builds", get(api_build_list).post(api_build_submit))
+        .route("/api/v1/builds/{id}", get(api_build_show))
+        .route("/api/v1/builds/{id}/logs", get(api_build_logs))
+        .route("/api/v1/builds/{id}/cancel", post(api_build_cancel))
         .layer(middleware::from_fn_with_state(
             web_state.clone(),
             auth_middleware,
@@ -1662,6 +1667,435 @@ async fn api_volume_adopt(State(state): State<Arc<WebState>>, req: Request) -> i
             };
             (status, Json(json!({ "error": msg }))).into_response()
         }
+    }
+}
+
+// ============================================================================
+// Build API (Build Tier v1 MVP, 2026-04-23)
+//
+// tenant の build ジョブを操作する endpoint 群。
+// 詳細設計: fleetstage repo docs/design/30-build-tier.md
+// ============================================================================
+
+/// GET /api/v1/builds — テナント配下の build job 一覧
+async fn api_build_list(State(state): State<Arc<WebState>>, req: Request) -> impl IntoResponse {
+    let ctx = req.extensions().get::<AuthContext>().unwrap();
+
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    let tenant_id = tenant.id.expect("tenant.id should exist after fetch");
+    match state.app.db.list_build_jobs_by_tenant(&tenant_id).await {
+        Ok(jobs) => {
+            let items: Vec<Value> = jobs
+                .iter()
+                .map(|j| {
+                    json!({
+                        "id": j.id,
+                        "kind": j.kind,
+                        "state": j.state,
+                        "git_url": j.source.git_url,
+                        "git_ref": j.source.git_ref,
+                        "dockerfile": j.source.dockerfile,
+                        "image": j.target.image,
+                        "logs_url": j.logs_url,
+                        "submitted_at": j.submitted_at.map(|d| d.to_rfc3339()),
+                        "started_at": j.started_at.map(|d| d.to_rfc3339()),
+                        "finished_at": j.finished_at.map(|d| d.to_rfc3339()),
+                        "duration_seconds": j.duration_seconds,
+                    })
+                })
+                .collect();
+            (StatusCode::OK, Json(json!({ "build_jobs": items }))).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/v1/builds — build job を submit (state=queued でエンキュー)
+///
+/// リクエスト body:
+/// ```json
+/// {
+///   "git_url": "https://github.com/chronista-club/fleetflow",
+///   "git_ref": "main",
+///   "dockerfile": "infra/Dockerfile.fleetflowd",
+///   "image": "ghcr.io/chronista-club/fleetflowd:latest",
+///   "kind": "docker-image"
+/// }
+/// ```
+async fn api_build_submit(State(state): State<Arc<WebState>>, req: Request) -> impl IntoResponse {
+    use fleetflow_controlplane::model::{
+        BuildJob, BuildSource, BuildTarget, build_job_kind, build_job_state,
+    };
+
+    let ctx = req
+        .extensions()
+        .get::<AuthContext>()
+        .expect("AuthContext missing")
+        .clone();
+
+    // 認可チェック: owner/admin のみ (インフラ操作)
+    if !ctx.can_operate() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Insufficient permissions" })),
+        )
+            .into_response();
+    }
+
+    let body = match axum::body::to_bytes(req.into_body(), 1024 * 16).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("invalid body: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+    let payload: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("invalid JSON: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+
+    let git_url = match payload["git_url"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`git_url` required" })),
+            )
+                .into_response();
+        }
+    };
+
+    let kind = payload["kind"]
+        .as_str()
+        .unwrap_or(build_job_kind::DOCKER_IMAGE);
+    if !build_job_kind::is_valid(kind) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": format!("invalid kind: {}", kind) })),
+        )
+            .into_response();
+    }
+
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let tenant_id = tenant.id.expect("tenant.id");
+
+    let job = BuildJob {
+        id: None,
+        tenant: tenant_id,
+        project: None,
+        kind: kind.to_string(),
+        source: BuildSource {
+            git_url,
+            git_ref: payload["git_ref"].as_str().unwrap_or("main").to_string(),
+            dockerfile: payload["dockerfile"].as_str().map(|s| s.to_string()),
+        },
+        target: BuildTarget {
+            image: payload["image"].as_str().map(|s| s.to_string()),
+            registry_secret: payload["registry_secret"].as_str().map(|s| s.to_string()),
+        },
+        state: build_job_state::QUEUED.to_string(),
+        server: None,
+        logs_url: None,
+        submitted_at: None,
+        started_at: None,
+        finished_at: None,
+        duration_seconds: None,
+    };
+
+    match state.app.db.create_build_job(&job).await {
+        Ok(created) => (
+            StatusCode::CREATED,
+            Json(json!({
+                "build_job": {
+                    "id": created.id,
+                    "kind": created.kind,
+                    "state": created.state,
+                    "git_url": created.source.git_url,
+                    "git_ref": created.source.git_ref,
+                    "dockerfile": created.source.dockerfile,
+                    "image": created.target.image,
+                    "submitted_at": created.submitted_at.map(|d| d.to_rfc3339()),
+                }
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            let msg = e.to_string();
+            let status = if msg.contains("invalid build job") {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, Json(json!({ "error": msg }))).into_response()
+        }
+    }
+}
+
+/// GET /api/v1/builds/{id} — build job 詳細取得
+async fn api_build_show(
+    State(state): State<Arc<WebState>>,
+    Path(id): Path<String>,
+    req: Request,
+) -> impl IntoResponse {
+    let ctx = req.extensions().get::<AuthContext>().unwrap();
+
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let tenant_id = tenant.id.expect("tenant.id");
+
+    let record_id = surrealdb::types::RecordId::from_table_key("build_job", id.as_str());
+    match state.app.db.get_build_job_by_id(&record_id).await {
+        Ok(Some(job)) => {
+            if job.tenant != tenant_id {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({ "error": "Access denied" })),
+                )
+                    .into_response();
+            }
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "build_job": {
+                        "id": job.id,
+                        "kind": job.kind,
+                        "state": job.state,
+                        "git_url": job.source.git_url,
+                        "git_ref": job.source.git_ref,
+                        "dockerfile": job.source.dockerfile,
+                        "image": job.target.image,
+                        "logs_url": job.logs_url,
+                        "submitted_at": job.submitted_at.map(|d| d.to_rfc3339()),
+                        "started_at": job.started_at.map(|d| d.to_rfc3339()),
+                        "finished_at": job.finished_at.map(|d| d.to_rfc3339()),
+                        "duration_seconds": job.duration_seconds,
+                    }
+                })),
+            )
+                .into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Build job not found" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /api/v1/builds/{id}/logs — build ログ参照 (v1: polling、logs_url を返すのみ)
+async fn api_build_logs(
+    State(state): State<Arc<WebState>>,
+    Path(id): Path<String>,
+    req: Request,
+) -> impl IntoResponse {
+    let ctx = req.extensions().get::<AuthContext>().unwrap();
+
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let tenant_id = tenant.id.expect("tenant.id");
+
+    let record_id = surrealdb::types::RecordId::from_table_key("build_job", id.as_str());
+    match state.app.db.get_build_job_by_id(&record_id).await {
+        Ok(Some(job)) => {
+            if job.tenant != tenant_id {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({ "error": "Access denied" })),
+                )
+                    .into_response();
+            }
+            // v1: logs_url を返すのみ (SSE stream は v2)
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "state": job.state,
+                    "logs_url": job.logs_url,
+                    "note": "v1 は polling。logs_url が Some の場合はそこから取得してください。",
+                })),
+            )
+                .into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Build job not found" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/v1/builds/{id}/cancel — build job をキャンセル
+async fn api_build_cancel(
+    State(state): State<Arc<WebState>>,
+    Path(id): Path<String>,
+    req: Request,
+) -> impl IntoResponse {
+    use fleetflow_controlplane::model::build_job_state;
+
+    let ctx = req
+        .extensions()
+        .get::<AuthContext>()
+        .expect("AuthContext missing")
+        .clone();
+
+    if !ctx.can_operate() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Insufficient permissions" })),
+        )
+            .into_response();
+    }
+
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let tenant_id = tenant.id.expect("tenant.id");
+
+    let record_id = surrealdb::types::RecordId::from_table_key("build_job", id.as_str());
+    match state.app.db.get_build_job_by_id(&record_id).await {
+        Ok(Some(job)) => {
+            if job.tenant != tenant_id {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({ "error": "Access denied" })),
+                )
+                    .into_response();
+            }
+            if job.state == build_job_state::SUCCESS
+                || job.state == build_job_state::FAILED
+                || job.state == build_job_state::CANCELLED
+            {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(json!({
+                        "error": format!("cannot cancel job in state: {}", job.state)
+                    })),
+                )
+                    .into_response();
+            }
+            match state
+                .app
+                .db
+                .update_build_job_state(&record_id, build_job_state::CANCELLED)
+                .await
+            {
+                Ok(()) => (StatusCode::OK, Json(json!({ "status": "cancelled" }))).into_response(),
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": e.to_string() })),
+                )
+                    .into_response(),
+            }
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Build job not found" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -1904,7 +1904,7 @@ async fn api_build_show(
     };
     let tenant_id = tenant.id.expect("tenant.id");
 
-    let record_id = surrealdb::types::RecordId::from_table_key("build_job", id.as_str());
+    let record_id = fleetflow_controlplane::RecordId::new("build_job", id.as_str());
     match state.app.db.get_build_job_by_id(&record_id).await {
         Ok(Some(job)) => {
             if job.tenant != tenant_id {
@@ -1975,7 +1975,7 @@ async fn api_build_logs(
     };
     let tenant_id = tenant.id.expect("tenant.id");
 
-    let record_id = surrealdb::types::RecordId::from_table_key("build_job", id.as_str());
+    let record_id = fleetflow_controlplane::RecordId::new("build_job", id.as_str());
     match state.app.db.get_build_job_by_id(&record_id).await {
         Ok(Some(job)) => {
             if job.tenant != tenant_id {
@@ -2050,7 +2050,7 @@ async fn api_build_cancel(
     };
     let tenant_id = tenant.id.expect("tenant.id");
 
-    let record_id = surrealdb::types::RecordId::from_table_key("build_job", id.as_str());
+    let record_id = fleetflow_controlplane::RecordId::new("build_job", id.as_str());
     match state.app.db.get_build_job_by_id(&record_id).await {
         Ok(Some(job)) => {
             if job.tenant != tenant_id {


### PR DESCRIPTION
## Summary

Fleetstage の 3 軸 tier モデル (Compute × Persistence × Build) の **Build Tier** v1 MVP。Persistence Tier #139/#140 に続く 3 軸目、同じ 3 層 (Unison handler + REST + CLI) pattern で実装。

設計 docs (fleetstage repo PR #27):
- \`docs/design/30-build-tier.md\` — アーキテクチャ 300 行
- \`docs/design/30-build-tier-worker-brief.md\` — 実装仕様

## 変更

- **9 files changed, 1722 insertions(+), 2 deletions(-)**
- NEW: \`crates/fleetflow-controlplane/src/handlers/build.rs\` (Unison handler)

## 機能

\`\`\`
fleet cp build submit --git <url> --git-ref main --dockerfile <path> --image <tag>
fleet cp build list
fleet cp build show <id>
fleet cp build logs <id>
fleet cp build cancel <id>
\`\`\`

\`POST /api/v1/builds\` → enqueue → Scheduler pick server → fleet-agent 経由で
\`git clone\` → \`fleetflow-build::build_image\` → \`docker push\`。

## 決定事項

1. **\`source.ref\` → \`source.git_ref\`** (schema + Rust + CLI 全層統一): SurrealDB 予約語回避
2. **\`fleet cp build\`** (top-level \`fleet build\` と clap が区別): 変な uglification なし
3. **既存 fleetflow-build crate 再利用**: ラッパ (ImageBuilder / ImagePusher) が main にすでに存在

## 非 scope (v1)

- Build VPS auto-provisioning (tier=build ラベル手動付与前提)
- 並列 scheduling (1 job = 1 VPS 順次)
- sccache / persistent cache → v2 (Persistence Tier D2 volume)
- SSE log stream (v1 polling)
- B2/B3 tier

## Test plan

- [x] \`cargo build --workspace\` green
- [x] \`cargo test --workspace --lib\` — 7 new build_job tests pass, no regression
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] \`cargo fmt --all\` 適用
- [x] \`fleet cp --help\` で \`build\` subcommand が listing される
- [ ] merge + cp.fleetstage.cloud redeploy 後、E2E: \`fleet cp build submit\` で image が ghcr.io に push される (dogfood: \`infra/Dockerfile.fleetflowd\` で fleetflowd 自身を Build Tier 経由で焼く)

## 開発プロセス

worker 委譲 (Agent tool + subagent_type=general-purpose + sonnet モデル) で 1 shot 実装。
Brief が詳細で naming / 構造 / test patterns まで全て指示済、worker は brief 通り実装。
最終 review で naming 1 点 (\`CpBuild\` → \`Build\`) を lead 側で修正、他は worker 判断そのまま採用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)