### PR TITLE
feat(api): FSC-17/18/19 — /api/v1/stages/.../status + restart + MCP tools

### DIFF
--- a/crates/fleetflow-mcp/src/lib.rs
+++ b/crates/fleetflow-mcp/src/lib.rs
@@ -115,6 +115,17 @@ pub struct StagePathParam {
     pub stage: String,
 }
 
+/// fleet_restart パラメータ（FSC-18）
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct FleetRestartParam {
+    /// プロジェクト slug
+    pub project: String,
+    /// ステージ名
+    pub stage: String,
+    /// 再起動するサービス名
+    pub service: String,
+}
+
 /// コンテナログ取得パラメータ
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct ContainerLogParam {
@@ -955,6 +966,35 @@ impl FleetFlowServer {
         Ok(result)
     }
 
+    // ============================================================
+    // FSC-17/18/19: Stage Runtime Status + Service Restart v1
+    // ============================================================
+
+    /// ステージの実 runtime status を取得 (FSC-17)
+    #[tool(
+        description = "ステージに含まれる各サービスの実 runtime status（running/stopped/restarting）と uptime_seconds を取得します。Agent → docker ps の結果を整形して返します。"
+    )]
+    async fn fleet_status(&self, params: Parameters<StagePathParam>) -> Result<String, String> {
+        let p = &params.0;
+        let path = format!("/api/v1/stages/{}/{}/status", p.project, p.stage);
+        let resp = cp::http_get(&path).await.map_err(|e| e.to_string())?;
+        Ok(serde_json::to_string_pretty(&resp).unwrap_or_else(|_| "OK".into()))
+    }
+
+    /// ステージのサービスを再起動 (FSC-18)
+    #[tool(
+        description = "指定ステージの指定サービスを Agent 経由で再起動します（docker restart）。owner/admin 権限が必要です。"
+    )]
+    async fn fleet_restart(&self, params: Parameters<FleetRestartParam>) -> Result<String, String> {
+        let p = &params.0;
+        let path = format!(
+            "/api/v1/stages/{}/{}/services/{}/restart",
+            p.project, p.stage, p.service,
+        );
+        let resp = cp::http_post(&path).await.map_err(|e| e.to_string())?;
+        Ok(serde_json::to_string_pretty(&resp).unwrap_or_else(|_| "OK".into()))
+    }
+
     /// CP 経由でプロジェクトの詳細を取得
     #[tool(
         description = "指定プロジェクトの詳細情報を取得します。プロジェクト名、説明、作成日時を表示します。"
@@ -1335,6 +1375,9 @@ mod tests {
         "fleetflow_cp_alerts",
         "fleetflow_cp_agents",
         "fleetflow_cp_tenant_users",
+        // FSC-17/18/19 stage runtime status + restart
+        "fleet_status",
+        "fleet_restart",
     ];
 
     #[test]

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -103,6 +103,15 @@ pub async fn start(
         .route("/api/v1/builds/{id}", get(api_build_show))
         .route("/api/v1/builds/{id}/logs", get(api_build_logs))
         .route("/api/v1/builds/{id}/cancel", post(api_build_cancel))
+        // Stage Runtime Status + Service Restart v1 (FSC-17/18, 2026-04-22)
+        .route(
+            "/api/v1/stages/{project}/{stage}/status",
+            get(api_v1_stage_status),
+        )
+        .route(
+            "/api/v1/stages/{project}/{stage}/services/{service}/restart",
+            post(api_v1_service_restart),
+        )
         .layer(middleware::from_fn_with_state(
             web_state.clone(),
             auth_middleware,
@@ -2100,6 +2109,256 @@ async fn api_build_cancel(
 }
 
 // ============================================================================
+// Stage Runtime Status + Service Restart v1 (FSC-17/18)
+// ============================================================================
+
+/// docker `Status` 文字列（例: "Up 3 days", "Up 2 hours"）から uptime を秒に変換する。
+/// 停止中・exited などは None を返す。
+pub fn uptime_from_docker_status(status: &str) -> Option<u64> {
+    // "Up X unit" 形式のみ対象
+    let lower = status.to_lowercase();
+    if !lower.starts_with("up ") {
+        return None;
+    }
+    let rest = lower.trim_start_matches("up ").trim();
+    // "X unit" を split して数値と単位を取る
+    let mut parts = rest.splitn(2, ' ');
+    let num: u64 = parts.next()?.parse().ok()?;
+    let unit = parts.next()?.trim().trim_end_matches('s'); // days → day, hours → hour
+    let seconds = match unit {
+        "second" => num,
+        "minute" => num * 60,
+        "hour" => num * 3600,
+        "day" => num * 86400,
+        "week" => num * 604800,
+        "month" => num * 2592000, // 30-day approximation
+        "year" => num * 31536000,
+        _ => return None,
+    };
+    Some(seconds)
+}
+
+/// docker `State` 文字列をレスポンス用の state 文字列に正規化する。
+pub fn state_from_docker_state(docker_state: &str) -> &'static str {
+    match docker_state.to_lowercase().as_str() {
+        "running" => "running",
+        "restarting" => "restarting",
+        "paused" => "stopped",
+        "exited" => "stopped",
+        "dead" => "stopped",
+        "created" => "stopped",
+        "removing" => "stopped",
+        _ => "unknown",
+    }
+}
+
+/// docker container name（例: "gfp-dev-gfp-web"）から service 名を逆引きする。
+/// フォーマット: `{project}-{stage}-{service_slug}` だが service_slug 自体に `-` を含む場合がある。
+/// → project と stage prefix を取り除く。
+pub fn container_name_to_service<'a>(
+    container_name: &'a str,
+    project: &str,
+    stage: &str,
+) -> Option<&'a str> {
+    let prefix = format!("{}-{}-", project, stage);
+    container_name.strip_prefix(&prefix)
+}
+
+/// GET /api/v1/stages/{project}/{stage}/status — ステージの実 runtime status
+async fn api_v1_stage_status(
+    State(state): State<Arc<WebState>>,
+    Path((project, stage)): Path<(String, String)>,
+    req: Request,
+) -> impl IntoResponse {
+    let ctx = req.extensions().get::<AuthContext>().unwrap();
+
+    // ステージ一覧から対象を特定（tenant scope 検証を兼ねる）
+    let stages = match state.app.db.list_stage_overviews(&ctx.tenant_slug).await {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    let target = stages
+        .iter()
+        .find(|s| s.project_slug == project && s.slug == stage);
+
+    let server_slug = match target.and_then(|s| s.server_slug.as_deref()) {
+        Some(s) => s.to_string(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Stage has no server assigned" })),
+            )
+                .into_response();
+        }
+    };
+
+    // CP に登録されているサービス一覧を取得（期待するサービス名の基準）
+    let registered_services = match state
+        .app
+        .db
+        .list_services_by_project_stage(&ctx.tenant_slug, &project, &stage)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    // Agent から docker ps 結果を取得
+    let agent_result = state
+        .app
+        .agent_registry
+        .send_command(&server_slug, "status", json!({}))
+        .await;
+
+    let containers_json = match agent_result {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": format!("agent unreachable: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+
+    // docker ps の結果をパース: containers は配列
+    let containers = containers_json["containers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+
+    // 登録サービスごとに、対応するコンテナを検索して status を組み立てる
+    let services: Vec<Value> = registered_services
+        .iter()
+        .map(|svc| {
+            // docker container の Names フィールドから service 名を逆引きして突合
+            let found = containers.iter().find(|c| {
+                c["Names"]
+                    .as_str()
+                    .map(|n| {
+                        let bare = n.trim_start_matches('/');
+                        container_name_to_service(bare, &project, &stage)
+                            .map(|s| s == svc.slug)
+                            .unwrap_or(false)
+                    })
+                    .unwrap_or(false)
+            });
+            match found {
+                Some(c) => {
+                    let docker_state = c["State"].as_str().unwrap_or("unknown");
+                    let state_str = state_from_docker_state(docker_state);
+                    let uptime = c["Status"]
+                        .as_str()
+                        .and_then(uptime_from_docker_status)
+                        .map(|s| json!(s))
+                        .unwrap_or(Value::Null);
+                    json!({
+                        "name": svc.slug,
+                        "state": state_str,
+                        "uptime_seconds": uptime,
+                        "image": c["Image"].as_str(),
+                        "container_id": c["ID"].as_str(),
+                    })
+                }
+                None => {
+                    json!({
+                        "name": svc.slug,
+                        "state": "stopped",
+                        "uptime_seconds": Value::Null,
+                        "image": Value::Null,
+                        "container_id": Value::Null,
+                    })
+                }
+            }
+        })
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "project": project,
+            "stage": stage,
+            "server": server_slug,
+            "services": services,
+        })),
+    )
+        .into_response()
+}
+
+/// POST /api/v1/stages/{project}/{stage}/services/{service}/restart — サービス再起動 v1 path
+///
+/// 既存 `/api/stages/{p}/{s}/restart/{service}` の REST-idiomatic 版。
+/// 旧 path は deprecate せず残す。
+async fn api_v1_service_restart(
+    State(state): State<Arc<WebState>>,
+    Path((project, stage, service)): Path<(String, String, String)>,
+    req: Request,
+) -> impl IntoResponse {
+    let ctx = req.extensions().get::<AuthContext>().unwrap();
+
+    // 認可チェック: owner/admin のみ（インフラ操作）
+    if !ctx.can_operate() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Insufficient permissions" })),
+        )
+            .into_response();
+    }
+
+    // ステージのサーバーを特定
+    let stages = match state.app.db.list_stage_overviews(&ctx.tenant_slug).await {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    let target = stages
+        .iter()
+        .find(|s| s.project_slug == project && s.slug == stage);
+
+    let server_slug = match target.and_then(|s| s.server_slug.as_deref()) {
+        Some(s) => s.to_string(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Stage has no server assigned" })),
+            )
+                .into_response();
+        }
+    };
+
+    let payload = json!({ "service": format!("{}-{}-{}", project, stage, service) });
+
+    match state
+        .app
+        .agent_registry
+        .send_command(&server_slug, "restart", payload)
+        .await
+    {
+        Ok(result) => (StatusCode::OK, Json(result)).into_response(),
+        Err(e) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({ "error": e }))).into_response(),
+    }
+}
+
+// ============================================================================
 // Dashboard HTML（埋め込み）
 // ============================================================================
 
@@ -2108,4 +2367,93 @@ async fn dashboard_html() -> impl IntoResponse {
         [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
         Html(include_str!("dashboard.html")),
     )
+}
+
+// ============================================================================
+// Unit tests (FSC-17 純粋ヘルパー)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- uptime_from_docker_status ---
+
+    #[test]
+    fn uptime_from_docker_status_days() {
+        assert_eq!(uptime_from_docker_status("Up 3 days"), Some(259200));
+    }
+
+    #[test]
+    fn uptime_from_docker_status_hours() {
+        assert_eq!(uptime_from_docker_status("Up 2 hours"), Some(7200));
+    }
+
+    #[test]
+    fn uptime_from_docker_status_minutes() {
+        assert_eq!(uptime_from_docker_status("Up 5 minutes"), Some(300));
+    }
+
+    #[test]
+    fn uptime_from_docker_status_seconds() {
+        assert_eq!(uptime_from_docker_status("Up 45 seconds"), Some(45));
+    }
+
+    #[test]
+    fn uptime_from_docker_status_exited_returns_none() {
+        assert_eq!(uptime_from_docker_status("Exited (0) 1 day ago"), None);
+    }
+
+    #[test]
+    fn uptime_from_docker_status_stopped_returns_none() {
+        assert_eq!(uptime_from_docker_status(""), None);
+    }
+
+    // --- state_from_docker_state ---
+
+    #[test]
+    fn state_from_docker_state_running() {
+        assert_eq!(state_from_docker_state("running"), "running");
+    }
+
+    #[test]
+    fn state_from_docker_state_exited() {
+        assert_eq!(state_from_docker_state("exited"), "stopped");
+    }
+
+    #[test]
+    fn state_from_docker_state_restarting() {
+        assert_eq!(state_from_docker_state("restarting"), "restarting");
+    }
+
+    #[test]
+    fn state_from_docker_state_unknown() {
+        assert_eq!(state_from_docker_state("dead"), "stopped");
+    }
+
+    // --- container_name_to_service ---
+
+    #[test]
+    fn container_name_to_service_basic() {
+        assert_eq!(
+            container_name_to_service("gfp-dev-gfp-web", "gfp", "dev"),
+            Some("gfp-web")
+        );
+    }
+
+    #[test]
+    fn container_name_to_service_no_match() {
+        assert_eq!(
+            container_name_to_service("other-prod-svc", "gfp", "dev"),
+            None
+        );
+    }
+
+    #[test]
+    fn container_name_to_service_hyphen_in_service_name() {
+        assert_eq!(
+            container_name_to_service("gfp-dev-gfp-estimate-worker", "gfp", "dev"),
+            Some("gfp-estimate-worker")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **FSC-17**: `GET /api/v1/stages/{project}/{stage}/status` — 実 runtime status (running/stopped + uptime) を返す新 REST endpoint
- **FSC-18**: `POST /api/v1/stages/{project}/{stage}/services/{service}/restart` — REST-idiomatic な service 再起動 path （旧 path は残す）
- **FSC-19**: MCP tools `fleet_status` + `fleet_restart` を `fleetflow-mcp` に追加

## Routes

| Method | Path | Handler | Auth |
|--------|------|---------|------|
| GET | `/api/v1/stages/{project}/{stage}/status` | `api_v1_stage_status` | auth_middleware (read-only) |
| POST | `/api/v1/stages/{project}/{stage}/services/{service}/restart` | `api_v1_service_restart` | auth_middleware + `can_operate()` |
| POST | `/api/stages/{project}/{stage}/restart/{service}` | `api_service_restart` (既存) | 残す (旧 path) |

## 実装ポイント

- `api_v1_stage_status`: `list_stage_overviews` で tenant scope 検証 → `list_services_by_project_stage` で登録サービス取得 → Agent `status` コマンドで docker ps 取得 → `container_name_to_service` で突合 → レスポンス整形
- uptime は docker `Status` 文字列（"Up 3 days"）を `uptime_from_docker_status()` で秒に変換
- server 未割当 → 404、agent 未接続 → 503

## Test plan

- [x] `cargo build --workspace` green
- [x] `cargo test --workspace --lib` — 全 12 crate, 0 failures
- [x] `cargo clippy --workspace --tests -- -D warnings` — warnings 0
- [x] `cargo fmt --all` 適用済み
- [x] `web::tests::uptime_from_docker_status_*` (days/hours/minutes/seconds/exited/empty)
- [x] `web::tests::state_from_docker_state_*` (running/exited/restarting/dead)
- [x] `web::tests::container_name_to_service_*` (basic/no-match/hyphen-in-name)
- [x] `fleetflow_mcp::tests::server_registers_all_tools` — fleet_status + fleet_restart 含む 26 tools
- [ ] `/api/v1/stages/.../status` 手動 E2E — fleet-agent 生き作業 VPS での実稼働確認が残

## Decisions / assumptions

1. `api_v1_service_restart` は `api_service_restart` のコピー（既存のものを呼ぶのではなく同ロジック）。将来の v1 固有の変更に備えてコピー方式を選択。
2. MCP tools の return type は既存パターン `Result<String, String>` に統一（brief の `CallToolResult` pseudocode とは異なるが、実際のコードベースに合わせた）。
3. `fleet_status` は `StagePathParam` を流用、`fleet_restart` は `FleetRestartParam`（service フィールド追加）を新規定義。

🤖 Generated with [Claude Code](https://claude.com/claude-code)