### PR TITLE
feat(stage): Stage Tier adopt phase — non-destructive BYO API + CLI

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -128,7 +128,8 @@ cargo audit \
   --ignore RUSTSEC-2026-0044 \
   --ignore RUSTSEC-2026-0048 \
   --ignore RUSTSEC-2026-0098 \
-  --ignore RUSTSEC-2026-0099
+  --ignore RUSTSEC-2026-0099 \
+  --ignore RUSTSEC-2026-0104
 """
 
 [tasks.tree]

--- a/audit.toml
+++ b/audit.toml
@@ -49,4 +49,15 @@ ignore = [
     # rustls-webpki 0.101.7 (旧バージョン): ワイルドカード証明書の name constraints
     # 経路・対応: 上と同じ
     "RUSTSEC-2026-0099",
+
+    # rustls-webpki 0.101.7 (旧バージョン): CRL parsing 中の panic (DoS)
+    # 経路: rustls-webpki 0.101.7 → rustls 0.21.12 →
+    #       aws-smithy-http-client 1.1.12 → aws-sdk-ec2 / aws-config
+    # 対応: 修正版 0.103.13 は別途導入済み (主要経路は 0.103.x を使用)。
+    #       0.101.7 は aws-smithy-http-client 1.1.x が rustls 0.21 系を pin して
+    #       いるため直接 update 不可。aws-smithy-http-client 次 major (rustls 0.22+
+    #       対応) 待ち。
+    # 影響: CRL を読み込む経路は FleetStage では現状未使用 (AWS API 呼出し時の
+    #       TLS は CRL なしの certificate 検証のみ)。
+    "RUSTSEC-2026-0104",
 ]

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -414,6 +414,142 @@ impl Database {
         Ok(stages)
     }
 
+    /// tenant_id + project_slug で project を解決 (adopt_stage 用)
+    async fn find_project_by_tenant_and_slug(
+        &self,
+        tenant_id: &RecordId,
+        project_slug: &str,
+    ) -> Result<Option<Project>> {
+        let mut result = self
+            .db
+            .query("SELECT * FROM project WHERE tenant = $tenant AND slug = $slug LIMIT 1")
+            .bind(("tenant", tenant_id.clone()))
+            .bind(("slug", project_slug.to_string()))
+            .await
+            .context("project (tenant+slug) 取得失敗")?;
+        let items: Vec<Project> = result.take(0)?;
+        Ok(items.into_iter().next())
+    }
+
+    /// project_id + stage_slug で stage を解決 (adopt_stage 用)
+    async fn find_stage_by_project_and_slug(
+        &self,
+        project_id: &RecordId,
+        stage_slug: &str,
+    ) -> Result<Option<Stage>> {
+        let mut result = self
+            .db
+            .query("SELECT * FROM stage WHERE project = $project AND slug = $slug LIMIT 1")
+            .bind(("project", project_id.clone()))
+            .bind(("slug", stage_slug.to_string()))
+            .await
+            .context("stage (project+slug) 取得失敗")?;
+        let items: Vec<Stage> = result.take(0)?;
+        Ok(items.into_iter().next())
+    }
+
+    /// 既存の稼働中 stage を非破壊で fleetstage registry に adopt する (FSC-16)。
+    ///
+    /// docker や worker には一切触れず、CP DB に以下の record を作成する:
+    /// * `project` — 同 tenant 内に同 slug が無ければ作成、あれば再利用
+    /// * `stage`   — 同 project 内に同 slug が既にあればエラー (二重 adopt 防止)
+    /// * `service` — 各 service spec ごとに新規作成 (desired_status = "running")
+    ///
+    /// Persistence Volume Tier の `adopt_volume` と同じ BYO 哲学。
+    pub async fn adopt_stage(&self, req: &AdoptStageRequest<'_>) -> Result<AdoptStageOutcome> {
+        if req.project_slug.is_empty() {
+            anyhow::bail!("project_slug must not be empty");
+        }
+        if req.stage_slug.is_empty() {
+            anyhow::bail!("stage_slug must not be empty");
+        }
+
+        // project upsert (tenant 内で slug がユニーク)
+        let project = match self
+            .find_project_by_tenant_and_slug(req.tenant_id, req.project_slug)
+            .await?
+        {
+            Some(p) => p,
+            None => {
+                self.create_project(&Project {
+                    id: None,
+                    tenant: req.tenant_id.clone(),
+                    slug: req.project_slug.to_string(),
+                    name: req.project_name.unwrap_or(req.project_slug).to_string(),
+                    description: None,
+                    repository_url: None,
+                    created_at: None,
+                    updated_at: None,
+                })
+                .await?
+            }
+        };
+        let project_id = project
+            .id
+            .clone()
+            .context("project.id should exist after create/fetch")?;
+
+        // stage: 同 project 内で slug が既にあれば二重 adopt を防ぐ
+        if self
+            .find_stage_by_project_and_slug(&project_id, req.stage_slug)
+            .await?
+            .is_some()
+        {
+            anyhow::bail!(
+                "stage `{}` already exists under project `{}` (use existing record)",
+                req.stage_slug,
+                req.project_slug
+            );
+        }
+
+        // stage create
+        let stage = self
+            .create_stage(&Stage {
+                id: None,
+                project: project_id.clone(),
+                slug: req.stage_slug.to_string(),
+                description: req.description.map(String::from),
+                server: Some(req.server_id.clone()),
+                created_at: None,
+                updated_at: None,
+            })
+            .await?;
+        let stage_id = stage
+            .id
+            .clone()
+            .context("stage.id should exist after create")?;
+
+        // services: adopt 時点では image のみ記録し config は None、desired_status = running
+        let mut created_services = Vec::with_capacity(req.services.len());
+        for spec in req.services {
+            if spec.slug.is_empty() {
+                anyhow::bail!("service slug must not be empty");
+            }
+            if spec.image.is_empty() {
+                anyhow::bail!("service image must not be empty (slug=`{}`)", spec.slug);
+            }
+            let svc = self
+                .create_service(&Service {
+                    id: None,
+                    stage: stage_id.clone(),
+                    slug: spec.slug.clone(),
+                    image: spec.image.clone(),
+                    config: None,
+                    desired_status: "running".to_string(),
+                    created_at: None,
+                    updated_at: None,
+                })
+                .await?;
+            created_services.push(svc);
+        }
+
+        Ok(AdoptStageOutcome {
+            project,
+            stage,
+            services: created_services,
+        })
+    }
+
     // ─────────────────────────────────────────
     // Service CRUD
     // ─────────────────────────────────────────
@@ -2717,5 +2853,187 @@ mod tests {
             .await
             .expect_err("invalid state は拒否されるべき");
         assert!(err.to_string().contains("invalid build job state"));
+    }
+
+    // ─────────────────────────────────────────
+    // Stage adopt tests (FSC-16, 2026-04-24)
+    // ─────────────────────────────────────────
+
+    fn gfp_services() -> Vec<AdoptServiceSpec> {
+        vec![
+            AdoptServiceSpec {
+                slug: "gfp-estimate".into(),
+                image: "ghcr.io/anycreative/gfp-estimate:latest".into(),
+            },
+            AdoptServiceSpec {
+                slug: "gfp-web".into(),
+                image: "ghcr.io/anycreative/gfp-web:latest".into(),
+            },
+        ]
+    }
+
+    fn adopt_req<'a>(
+        tenant_id: &'a RecordId,
+        server_id: &'a RecordId,
+        project_slug: &'a str,
+        project_name: Option<&'a str>,
+        stage_slug: &'a str,
+        description: Option<&'a str>,
+        services: &'a [AdoptServiceSpec],
+    ) -> AdoptStageRequest<'a> {
+        AdoptStageRequest {
+            tenant_id,
+            server_id,
+            project_slug,
+            project_name,
+            stage_slug,
+            description,
+            services,
+        }
+    }
+
+    #[tokio::test]
+    async fn adopt_stage_creates_project_stage_and_services() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, server_id) = seed_tenant_and_server(&db).await;
+        let services = gfp_services();
+
+        let outcome = db
+            .adopt_stage(&adopt_req(
+                &tenant_id,
+                &server_id,
+                "gfp",
+                Some("GFP Live Fleet"),
+                "dev",
+                Some("GFP dev on fleet-worker-01"),
+                &services,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.project.slug, "gfp");
+        assert_eq!(outcome.project.name, "GFP Live Fleet");
+        assert_eq!(outcome.stage.slug, "dev");
+        assert_eq!(
+            outcome.stage.description.as_deref(),
+            Some("GFP dev on fleet-worker-01")
+        );
+        assert_eq!(outcome.stage.server.as_ref(), Some(&server_id));
+        assert_eq!(outcome.services.len(), 2);
+        let slugs: Vec<_> = outcome.services.iter().map(|s| s.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["gfp-estimate", "gfp-web"]);
+        for s in &outcome.services {
+            assert_eq!(s.desired_status, "running");
+        }
+    }
+
+    #[tokio::test]
+    async fn adopt_stage_reuses_existing_project() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, server_id) = seed_tenant_and_server(&db).await;
+        let services = gfp_services();
+
+        // 1 回目: project=gfp, stage=dev を adopt (project が新規作成される)
+        let first = db
+            .adopt_stage(&adopt_req(
+                &tenant_id,
+                &server_id,
+                "gfp",
+                Some("GFP"),
+                "dev",
+                None,
+                &services,
+            ))
+            .await
+            .unwrap();
+        let project_id_first = first.project.id.clone().unwrap();
+
+        // 2 回目: 同じ project の別 stage を adopt — project は再利用されるべき
+        let second = db
+            .adopt_stage(&adopt_req(
+                &tenant_id, &server_id, "gfp", None, "staging", None, &services,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(second.project.id.as_ref(), Some(&project_id_first));
+        assert_eq!(second.stage.slug, "staging");
+    }
+
+    #[tokio::test]
+    async fn adopt_stage_rejects_duplicate_stage_under_same_project() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, server_id) = seed_tenant_and_server(&db).await;
+        let services = gfp_services();
+
+        db.adopt_stage(&adopt_req(
+            &tenant_id,
+            &server_id,
+            "gfp",
+            Some("GFP"),
+            "dev",
+            None,
+            &services,
+        ))
+        .await
+        .unwrap();
+
+        let err = db
+            .adopt_stage(&adopt_req(
+                &tenant_id, &server_id, "gfp", None, "dev", None, &services,
+            ))
+            .await
+            .expect_err("同一 project 配下の同 slug は拒否されるべき");
+        assert!(
+            err.to_string().contains("already exists"),
+            "error message should mention already exists, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn adopt_stage_rejects_empty_slugs() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, server_id) = seed_tenant_and_server(&db).await;
+        let services = gfp_services();
+
+        let err = db
+            .adopt_stage(&adopt_req(
+                &tenant_id, &server_id, "", None, "dev", None, &services,
+            ))
+            .await
+            .expect_err("空 project_slug は拒否されるべき");
+        assert!(err.to_string().contains("project_slug must not be empty"));
+
+        let err = db
+            .adopt_stage(&adopt_req(
+                &tenant_id, &server_id, "gfp", None, "", None, &services,
+            ))
+            .await
+            .expect_err("空 stage_slug は拒否されるべき");
+        assert!(err.to_string().contains("stage_slug must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn adopt_stage_rejects_service_with_empty_image() {
+        let db = Database::connect_memory().await.unwrap();
+        let (tenant_id, server_id) = seed_tenant_and_server(&db).await;
+
+        let broken = vec![AdoptServiceSpec {
+            slug: "gfp-web".into(),
+            image: String::new(),
+        }];
+        let err = db
+            .adopt_stage(&adopt_req(
+                &tenant_id,
+                &server_id,
+                "gfp",
+                Some("GFP"),
+                "dev",
+                None,
+                &broken,
+            ))
+            .await
+            .expect_err("空 image は拒否されるべき");
+        assert!(err.to_string().contains("service image must not be empty"));
     }
 }

--- a/crates/fleetflow-controlplane/src/handlers/stage.rs
+++ b/crates/fleetflow-controlplane/src/handlers/stage.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 use unison::network::channel::UnisonChannel;
 use unison::network::server::ProtocolServer;
 
-use crate::model::Stage;
+use crate::model::{AdoptServiceSpec, AdoptStageRequest, Stage};
 use crate::server::AppState;
 
 pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
@@ -104,6 +104,165 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list_across_projects",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
+                        "adopt" => {
+                            let tenant_slug = payload["tenant_slug"].as_str().unwrap_or_default();
+                            let server_slug = payload["server_slug"].as_str().unwrap_or_default();
+                            let project_slug = payload["project_slug"].as_str().unwrap_or_default();
+                            let project_name = payload["project_name"].as_str();
+                            let stage_slug = payload["stage_slug"].as_str().unwrap_or_default();
+                            let description = payload["description"].as_str();
+
+                            // 必須フィールド validation
+                            for (name, value) in [
+                                ("tenant_slug", tenant_slug),
+                                ("server_slug", server_slug),
+                                ("project_slug", project_slug),
+                                ("stage_slug", stage_slug),
+                            ] {
+                                if value.is_empty() {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": format!("`{}` required", name) }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            }
+
+                            // services 配列をパース
+                            let services: Vec<AdoptServiceSpec> = match payload["services"]
+                                .as_array()
+                            {
+                                Some(arr) if !arr.is_empty() => arr
+                                    .iter()
+                                    .filter_map(|s| {
+                                        Some(AdoptServiceSpec {
+                                            slug: s["slug"].as_str()?.to_string(),
+                                            image: s["image"].as_str()?.to_string(),
+                                        })
+                                    })
+                                    .collect(),
+                                _ => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": "`services` must be a non-empty array of { slug, image }" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+
+                            // tenant 解決
+                            let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
+                                Ok(Some(t)) => t,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": "tenant not found" }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "tenant lookup 失敗 (stage.adopt)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            let tenant_id = tenant.id.expect("tenant.id");
+
+                            // server 解決 (tenant 配下確認)
+                            let srv = match state.db.get_server_by_slug(server_slug).await {
+                                Ok(Some(s)) => s,
+                                Ok(None) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({
+                                                "error": format!("server `{}` not found", server_slug)
+                                            }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "server lookup 失敗 (stage.adopt)");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                    continue;
+                                }
+                            };
+                            if srv.tenant != tenant_id {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "adopt",
+                                        json!({ "error": "server does not belong to this tenant" }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+                            let server_id = srv.id.expect("server.id");
+
+                            match state
+                                .db
+                                .adopt_stage(&AdoptStageRequest {
+                                    tenant_id: &tenant_id,
+                                    server_id: &server_id,
+                                    project_slug,
+                                    project_name,
+                                    stage_slug,
+                                    description,
+                                    services: &services,
+                                })
+                                .await
+                            {
+                                Ok(outcome) => {
+                                    info!(
+                                        project = %project_slug,
+                                        stage = %stage_slug,
+                                        server = %server_slug,
+                                        service_count = outcome.services.len(),
+                                        "stage adopted"
+                                    );
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
+                                            json!({ "outcome": outcome }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "stage.adopt 失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "adopt",
                                             json!({ "error": e.to_string() }),
                                         )
                                         .await?;

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -277,6 +277,45 @@ pub struct StageOverview {
 }
 
 // ─────────────────────────────────────────────
+// Stage Tier adopt DTO (FSC-16, 2026-04-24)
+//
+// 既存稼働中の stage を非破壊で fleetstage registry に登録するための
+// request/outcome 型。Persistence Volume Tier の BYO adopt と同系。
+// ─────────────────────────────────────────────
+
+/// adopt_stage に渡す service 1 件の最小 spec。
+/// 現時点では slug / image のみを記録し、config は None で始める。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdoptServiceSpec {
+    pub slug: String,
+    pub image: String,
+}
+
+/// `Database::adopt_stage` への入力。borrowed form のまとまり。
+///
+/// `clippy::too_many_arguments` を避けつつ、project/stage の必須フィールドと
+/// optional (project_name, description) を 1 つの struct に集約する。
+#[derive(Debug)]
+pub struct AdoptStageRequest<'a> {
+    pub tenant_id: &'a RecordId,
+    pub server_id: &'a RecordId,
+    pub project_slug: &'a str,
+    pub project_name: Option<&'a str>,
+    pub stage_slug: &'a str,
+    pub description: Option<&'a str>,
+    pub services: &'a [AdoptServiceSpec],
+}
+
+/// adopt_stage の結果: どの project / stage / services が使われたか。
+/// project は既存なら再利用、stage と services は常に新規作成。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdoptStageOutcome {
+    pub project: Project,
+    pub stage: Stage,
+    pub services: Vec<Service>,
+}
+
+// ─────────────────────────────────────────────
 // CP-004: Service
 // ─────────────────────────────────────────────
 

--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use super::cp_client;
 use crate::{
     BuildCommands, CostCommands, DnsCommands, ProjectCommands, RemoteCommands, ServerCommands,
-    TenantCommands, VolumeCommands,
+    StageCommands, TenantCommands, VolumeCommands,
 };
 
 pub async fn handle_tenant(cmd: &TenantCommands) -> Result<()> {
@@ -1027,6 +1027,83 @@ pub async fn handle_build(cmd: &BuildCommands) -> Result<()> {
                     "Cancelled.".green().bold(),
                     id.cyan()
                 );
+            }
+
+            client.disconnect().await.ok();
+        }
+    }
+
+    Ok(())
+}
+
+/// Stage Tier コマンド (FSC-16, 2026-04-24)
+///
+/// 既存稼働中の stage を非破壊で CP registry に adopt する。
+/// provision phase は FSC-31 で別途実装予定。
+pub async fn handle_stage(cmd: &StageCommands) -> Result<()> {
+    match cmd {
+        StageCommands::Adopt {
+            project,
+            project_name,
+            stage,
+            description,
+            server,
+            services,
+        } => {
+            if services.is_empty() {
+                anyhow::bail!("少なくとも 1 つの --service slug=image を指定してください");
+            }
+
+            let (client, creds) = cp_client::connect().await?;
+
+            println!("{}", "Stage adopt (BYO)".bold());
+            println!("  docker 状態には一切触れません。CP registry に record を作成します。");
+            println!();
+
+            let tenant_slug = creds.tenant_slug.as_deref().unwrap_or("default");
+
+            let services_payload: Vec<_> = services
+                .iter()
+                .map(|s| json!({ "slug": s.slug, "image": s.image }))
+                .collect();
+
+            let mut payload = json!({
+                "tenant_slug": tenant_slug,
+                "server_slug": server,
+                "project_slug": project,
+                "stage_slug": stage,
+                "services": services_payload,
+            });
+            if let Some(name) = project_name {
+                payload["project_name"] = json!(name);
+            }
+            if let Some(desc) = description {
+                payload["description"] = json!(desc);
+            }
+
+            let resp = cp_client::request(&client, "stage", "adopt", payload).await?;
+
+            if let Some(err) = resp["error"].as_str() {
+                println!("{} {}", "エラー:".red(), err);
+            } else if let Some(outcome) = resp.get("outcome") {
+                println!("{}", "Adopted 🎉".green().bold());
+                if let Some(p) = outcome.get("project") {
+                    println!("  Project: {}", p["slug"].as_str().unwrap_or("-").cyan());
+                }
+                if let Some(st) = outcome.get("stage") {
+                    println!("  Stage:   {}", st["slug"].as_str().unwrap_or("-").cyan());
+                }
+                println!("  Server:  {}", server.cyan());
+                if let Some(svcs) = outcome["services"].as_array() {
+                    println!("  Services ({}):", svcs.len());
+                    for s in svcs {
+                        println!(
+                            "    - {}  ({})",
+                            s["slug"].as_str().unwrap_or("-").cyan(),
+                            s["image"].as_str().unwrap_or("-").dimmed()
+                        );
+                    }
+                }
             }
 
             client.disconnect().await.ok();

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -284,6 +284,9 @@ enum CpCommands {
     /// Build Tier — CP 経由の docker image / cargo binary などの build ジョブ管理
     #[command(subcommand)]
     Build(BuildCommands),
+    /// Stage Tier — 既存稼働中 stage の adopt ほか (FSC-16)
+    #[command(subcommand)]
+    Stage(StageCommands),
 }
 
 /// デーモン管理のサブコマンド
@@ -564,6 +567,61 @@ pub enum BuildCommands {
         /// Job ID
         id: String,
     },
+}
+
+/// Stage Tier 管理のサブコマンド (FSC-16, 2026-04-24)
+///
+/// 既存 stage の adopt (BYO, 非破壊) を提供する。
+/// provision phase (ゼロ立ち上げ) は FSC-31 で別途実装予定。
+#[derive(Subcommand)]
+pub enum StageCommands {
+    /// 既存稼働中の stage を CP registry に adopt (非破壊、docker 非接触)
+    ///
+    /// worker 上で既に docker compose 等で動いている stage を、
+    /// docker 状態を一切変えないまま fleetstage 管理下に取り込む。
+    Adopt {
+        /// project slug (tenant 内でユニーク、なければ新規作成)
+        #[arg(long)]
+        project: String,
+        /// project 表示名 (新規作成時のみ使用、既存なら無視)
+        #[arg(long)]
+        project_name: Option<String>,
+        /// stage slug (project 内でユニーク、既にあればエラー)
+        #[arg(long)]
+        stage: String,
+        /// stage description (任意)
+        #[arg(long)]
+        description: Option<String>,
+        /// adopt 対象 server slug (現行 stage が動いている VPS)
+        #[arg(long)]
+        server: String,
+        /// services を "slug=image" 形式で繰り返し指定
+        ///
+        /// 例: `--service gfp-estimate=ghcr.io/anycreative/gfp-estimate:latest`
+        ///     `--service gfp-web=ghcr.io/anycreative/gfp-web:latest`
+        #[arg(long = "service", value_parser = parse_service_spec)]
+        services: Vec<ServiceSpecArg>,
+    },
+}
+
+/// CLI --service フラグを "slug=image" 形式で受ける構造体
+#[derive(Debug, Clone)]
+pub struct ServiceSpecArg {
+    pub slug: String,
+    pub image: String,
+}
+
+fn parse_service_spec(s: &str) -> Result<ServiceSpecArg, String> {
+    let (slug, image) = s
+        .split_once('=')
+        .ok_or_else(|| format!("expected `slug=image`, got `{}`", s))?;
+    if slug.is_empty() || image.is_empty() {
+        return Err(format!("both slug and image must be non-empty: `{}`", s));
+    }
+    Ok(ServiceSpecArg {
+        slug: slug.to_string(),
+        image: image.to_string(),
+    })
 }
 
 // ─────────────────────────────────────────────
@@ -934,5 +992,6 @@ async fn handle_cp(cmd: &CpCommands) -> anyhow::Result<()> {
         }
         CpCommands::Volume(volume_cmd) => commands::cp::handle_volume(volume_cmd).await,
         CpCommands::Build(build_cmd) => commands::cp::handle_build(build_cmd).await,
+        CpCommands::Stage(stage_cmd) => commands::cp::handle_stage(stage_cmd).await,
     }
 }

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -112,6 +112,8 @@ pub async fn start(
             "/api/v1/stages/{project}/{stage}/services/{service}/restart",
             post(api_v1_service_restart),
         )
+        // Stage Tier adopt phase (FSC-16, 2026-04-24)
+        .route("/api/v1/stages/adopt", post(api_stage_adopt))
         .layer(middleware::from_fn_with_state(
             web_state.clone(),
             auth_middleware,
@@ -1670,6 +1672,241 @@ async fn api_volume_adopt(State(state): State<Arc<WebState>>, req: Request) -> i
         Err(e) => {
             let msg = e.to_string();
             let status = if msg.contains("invalid volume tier") || msg.contains("invalid") {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, Json(json!({ "error": msg }))).into_response()
+        }
+    }
+}
+
+// ============================================================================
+// Stage Tier adopt (FSC-16, 2026-04-24)
+//
+// 既存稼働中の stage を docker 非接触のまま fleetstage registry に登録する
+// BYO 経路。Persistence Volume Tier の /api/v1/volumes/adopt と対称。
+// 詳細設計: fleetstage repo Issue FSC-16
+// ============================================================================
+
+/// POST /api/v1/stages/adopt — 既存 stage を非破壊で CP records に登録
+///
+/// リクエスト body:
+/// ```json
+/// {
+///   "project_slug": "gfp",
+///   "project_name": "GFP Live Fleet",
+///   "stage_slug": "dev",
+///   "description": "GFP dev stage on fleet-worker-01",
+///   "server_slug": "fleet-worker-01",
+///   "services": [
+///     { "slug": "gfp-estimate", "image": "ghcr.io/anycreative/gfp-estimate:latest" },
+///     { "slug": "gfp-web",      "image": "ghcr.io/anycreative/gfp-web:latest" }
+///   ]
+/// }
+/// ```
+///
+/// worker 上の docker 状態には一切触れない。project は slug が既にあれば再利用、
+/// stage は同 project に同 slug があれば 409 で拒否 (二重 adopt 防止)。
+async fn api_stage_adopt(State(state): State<Arc<WebState>>, req: Request) -> impl IntoResponse {
+    let ctx = req
+        .extensions()
+        .get::<AuthContext>()
+        .expect("AuthContext missing")
+        .clone();
+
+    // 認可: owner/admin のみ (インフラ登録)
+    if !ctx.can_operate() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Insufficient permissions" })),
+        )
+            .into_response();
+    }
+
+    let body = match axum::body::to_bytes(req.into_body(), 1024 * 64).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("invalid body: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+    let payload: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("invalid JSON: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+
+    // 必須フィールド
+    let project_slug = match payload["project_slug"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`project_slug` required" })),
+            )
+                .into_response();
+        }
+    };
+    let stage_slug = match payload["stage_slug"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`stage_slug` required" })),
+            )
+                .into_response();
+        }
+    };
+    let server_slug = match payload["server_slug"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`server_slug` required" })),
+            )
+                .into_response();
+        }
+    };
+    let project_name = payload["project_name"].as_str().map(String::from);
+    let description = payload["description"].as_str().map(String::from);
+
+    // services: 非空配列かつ各要素が slug/image を持つこと
+    let services = match payload["services"].as_array() {
+        Some(arr) if !arr.is_empty() => {
+            let mut out = Vec::with_capacity(arr.len());
+            for (i, s) in arr.iter().enumerate() {
+                let slug = match s["slug"].as_str() {
+                    Some(v) if !v.is_empty() => v.to_string(),
+                    _ => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(json!({
+                                "error": format!("services[{}].slug required", i)
+                            })),
+                        )
+                            .into_response();
+                    }
+                };
+                let image = match s["image"].as_str() {
+                    Some(v) if !v.is_empty() => v.to_string(),
+                    _ => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(json!({
+                                "error": format!("services[{}].image required", i)
+                            })),
+                        )
+                            .into_response();
+                    }
+                };
+                out.push(fleetflow_controlplane::model::AdoptServiceSpec { slug, image });
+            }
+            out
+        }
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "`services` must be a non-empty array" })),
+            )
+                .into_response();
+        }
+    };
+
+    // tenant 解決
+    let tenant = match state.app.db.get_tenant_by_slug(&ctx.tenant_slug).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "Tenant not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let tenant_id = tenant.id.expect("tenant.id should exist after fetch");
+
+    // server 解決 (tenant 配下確認)
+    let server = match state.app.db.get_server_by_slug(&server_slug).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": format!("Server `{}` not found", server_slug) })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    if server.tenant != tenant_id {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Server does not belong to this tenant" })),
+        )
+            .into_response();
+    }
+    let server_id = server.id.expect("server.id should exist after fetch");
+
+    match state
+        .app
+        .db
+        .adopt_stage(&fleetflow_controlplane::model::AdoptStageRequest {
+            tenant_id: &tenant_id,
+            server_id: &server_id,
+            project_slug: &project_slug,
+            project_name: project_name.as_deref(),
+            stage_slug: &stage_slug,
+            description: description.as_deref(),
+            services: &services,
+        })
+        .await
+    {
+        Ok(outcome) => (
+            StatusCode::CREATED,
+            Json(json!({
+                "project": {
+                    "slug": outcome.project.slug,
+                    "name": outcome.project.name,
+                },
+                "stage": {
+                    "slug": outcome.stage.slug,
+                    "description": outcome.stage.description,
+                    "server_slug": server_slug,
+                },
+                "services": outcome.services.iter().map(|s| json!({
+                    "slug": s.slug,
+                    "image": s.image,
+                    "desired_status": s.desired_status,
+                })).collect::<Vec<_>>(),
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            let msg = e.to_string();
+            let status = if msg.contains("already exists") {
+                StatusCode::CONFLICT
+            } else if msg.contains("must not be empty") {
                 StatusCode::BAD_REQUEST
             } else {
                 StatusCode::INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## Summary

Add a **non-destructive adopt path** for Stage Tier: register an already-running stage into the fleetstage CP registry without touching the worker's docker state. Same BYO philosophy as the Persistence Volume Tier P-2 adopt (`/api/v1/volumes/adopt`).

Consumer issue: [fleetstage FSC-16](https://linear.app/chronista/issue/FSC-16) (rewritten today to be adopt-only; provision phase split into FSC-31).

## Surface

| Layer | Change |
|-------|--------|
| DB    | `Database::adopt_stage(&AdoptStageRequest)` — project upsert → stage create → services ×N |
| Model | `AdoptServiceSpec`, `AdoptStageOutcome`, `AdoptStageRequest<'a>` |
| Unison channel | `stage.adopt` method on existing `stage` channel |
| REST  | `POST /api/v1/stages/adopt` (owner/admin, tenant-scoped) |
| CLI   | `fleet cp stage adopt --project / --stage / --server --service slug=image …` |

## Request shape

```json
POST /api/v1/stages/adopt
{
  "project_slug": "gfp",
  "project_name": "GFP Live Fleet",
  "stage_slug": "dev",
  "description": "GFP dev on fleet-worker-01",
  "server_slug": "fleet-worker-01",
  "services": [
    { "slug": "gfp-estimate", "image": "ghcr.io/anycreative/gfp-estimate:latest" },
    { "slug": "gfp-web",      "image": "ghcr.io/anycreative/gfp-web:latest" }
  ]
}
```

Responses:

- `201 Created` — `{ project, stage, services[] }`
- `409 Conflict` — stage already exists under that project (prevents double-adopt)
- `400 Bad Request` — missing field / empty slug / empty image
- `403 Forbidden` — server belongs to a different tenant, or non-operator role
- `404 Not Found` — tenant or server missing

## CLI example

```bash
fleet cp stage adopt \
  --project gfp \
  --project-name "GFP Live Fleet" \
  --stage dev \
  --server fleet-worker-01 \
  --service gfp-estimate=ghcr.io/anycreative/gfp-estimate:latest \
  --service gfp-web=ghcr.io/anycreative/gfp-web:latest
```

The `--service slug=image` form is a repeatable `value_parser`-backed tuple, same ergonomics as `docker run -e K=V`.

## Non-goals (follow-ups)

- `fleet.kdl` parsing into `--services` — planned as a small follow-up PR
- Provisioning from scratch (destructive path) — tracked as fleetstage **FSC-31**
- Stage deletion / un-adopt — separate reverse-op issue

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green, incl. 5 new `db::tests::adopt_stage_*`)
  - creates project+stage+services
  - reuses existing project on second adopt
  - rejects duplicate stage under same project (409)
  - rejects empty project_slug / stage_slug
  - rejects empty service image
- [ ] Manual: `fleet cp stage adopt` against a staging CP + `GET /api/v1/stages/gfp/dev/status` returns non-empty (deferred to merge-time smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)