### PR TITLE
chore(deps): bump unison f3542df → 6a37611 (v0.4.1) — USN-2/3 migration [DRAFT, server rebuild required]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ aes-gcm = "0.10"
 # KDL parser
 kdl = "6"
 unison-kdl = { git = "https://github.com/chronista-club/unison-kdl", rev = "a5a37ce" }
-unison = { git = "https://github.com/chronista-club/unison", rev = "f3542df" }
+unison = { git = "https://github.com/chronista-club/unison", rev = "6a37611" }
 
 # Template engine
 tera = "1"

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -95,10 +95,10 @@ async fn command_loop(
         .context("agent チャネルオープン失敗")?;
 
     // Agent 登録
-    let register_resp = channel
+    let register_resp: serde_json::Value = channel
         .request(
             "register",
-            json!({
+            &json!({
                 "server_slug": server_slug,
                 "version": env!("CARGO_PKG_VERSION"),
             }),
@@ -128,7 +128,7 @@ async fn command_loop(
                     Ok(()) => json!({ "status": "ok" }),
                     Err(e) => json!({ "status": "failed", "error": e.to_string() }),
                 };
-                channel.send_response(msg.id, "restart", response).await?;
+                channel.send_response(msg.id, "restart", &response).await?;
             }
             "status" => {
                 let result = deploy::container_status().await;
@@ -136,14 +136,14 @@ async fn command_loop(
                     Ok(v) => json!({ "status": "ok", "data": v }),
                     Err(e) => json!({ "status": "failed", "error": e.to_string() }),
                 };
-                channel.send_response(msg.id, "status", response).await?;
+                channel.send_response(msg.id, "status", &response).await?;
             }
             "build" => {
                 handle_build(&channel, msg.id, &payload).await?;
             }
             "ping" => {
                 channel
-                    .send_response(msg.id, "ping", json!({ "pong": true }))
+                    .send_response(msg.id, "ping", &json!({ "pong": true }))
                     .await?;
             }
             method => {
@@ -152,7 +152,7 @@ async fn command_loop(
                     .send_response(
                         msg.id,
                         method,
-                        json!({ "error": format!("unknown command: {}", method) }),
+                        &json!({ "error": format!("unknown command: {}", method) }),
                     )
                     .await?;
             }
@@ -196,7 +196,7 @@ async fn handle_deploy(
         let _ = channel_for_log
             .send_event(
                 "deploy_log",
-                json!({
+                &json!({
                     "request_id": request_id,
                     "line": line,
                 }),
@@ -220,7 +220,7 @@ async fn handle_deploy(
     // deploy のビジネスエラーはレスポンスに含め、セッション切断しない
     // チャネル送信エラーのみ伝播（ネットワーク断）
     channel
-        .send_response(request_id, "deploy", response)
+        .send_response(request_id, "deploy", &response)
         .await?;
 
     Ok(())
@@ -251,7 +251,7 @@ async fn handle_build(
             .send_response(
                 request_id,
                 "build",
-                json!({ "status": "failed", "error": "git_url required" }),
+                &json!({ "status": "failed", "error": "git_url required" }),
             )
             .await?;
         return Ok(());
@@ -264,7 +264,7 @@ async fn handle_build(
             .send_response(
                 request_id,
                 "build",
-                json!({ "status": "failed", "error": format!("work dir 作成失敗: {}", e) }),
+                &json!({ "status": "failed", "error": format!("work dir 作成失敗: {}", e) }),
             )
             .await?;
         return Ok(());
@@ -288,7 +288,7 @@ async fn handle_build(
                 .send_response(
                     request_id,
                     "build",
-                    json!({ "status": "failed", "error": err }),
+                    &json!({ "status": "failed", "error": err }),
                 )
                 .await?;
             return Ok(());
@@ -300,7 +300,7 @@ async fn handle_build(
                 .send_response(
                     request_id,
                     "build",
-                    json!({ "status": "failed", "error": err }),
+                    &json!({ "status": "failed", "error": err }),
                 )
                 .await?;
             return Ok(());
@@ -318,7 +318,7 @@ async fn handle_build(
                 .send_response(
                     request_id,
                     "build",
-                    json!({ "status": "failed", "error": err }),
+                    &json!({ "status": "failed", "error": err }),
                 )
                 .await?;
             return Ok(());
@@ -355,7 +355,7 @@ async fn handle_build(
                 .send_response(
                     request_id,
                     "build",
-                    json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
+                    &json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
                 )
                 .await?;
             return Ok(());
@@ -380,7 +380,7 @@ async fn handle_build(
                     .send_response(
                         request_id,
                         "build",
-                        json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
+                        &json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
                     )
                     .await?;
                 return Ok(());
@@ -392,7 +392,7 @@ async fn handle_build(
                     .send_response(
                         request_id,
                         "build",
-                        json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
+                        &json!({ "status": "failed", "error": err, "duration_ms": duration_ms }),
                     )
                     .await?;
                 return Ok(());
@@ -407,7 +407,7 @@ async fn handle_build(
         .send_response(
             request_id,
             "build",
-            json!({
+            &json!({
                 "status": "success",
                 "image": image,
                 "duration_ms": duration_ms,

--- a/crates/fleet-agent/src/heartbeat.rs
+++ b/crates/fleet-agent/src/heartbeat.rs
@@ -23,10 +23,10 @@ pub async fn run_loop(client: &Arc<ProtocolClient>, server_slug: &str, interval_
 async fn send_heartbeat(client: &ProtocolClient, server_slug: &str) -> anyhow::Result<()> {
     let channel = client.open_channel("health").await?;
 
-    channel
+    let _: serde_json::Value = channel
         .request(
             "heartbeat",
-            json!({
+            &json!({
                 "server_slug": server_slug,
                 "agent_version": env!("CARGO_PKG_VERSION"),
             }),

--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -318,10 +318,10 @@ async fn send_resolve(
 ) -> anyhow::Result<()> {
     let channel = client.open_channel("server").await?;
 
-    channel
+    let _: serde_json::Value = channel
         .request(
             "alert_resolve",
-            json!({
+            &json!({
                 "server_slug": server_slug,
                 "container_name": container_name,
             }),
@@ -340,10 +340,10 @@ async fn send_alert(
 ) -> anyhow::Result<()> {
     let channel = client.open_channel("server").await?;
 
-    channel
+    let _: serde_json::Value = channel
         .request(
             "alert",
-            json!({
+            &json!({
                 "server_slug": server_slug,
                 "container_name": alert.container_name,
                 "alert_type": alert.alert_type.as_str(),

--- a/crates/fleetflow-controlplane/src/handlers/agent.rs
+++ b/crates/fleetflow-controlplane/src/handlers/agent.rs
@@ -34,7 +34,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                         .send_response(
                             msg.id,
                             &msg.method,
-                            json!({ "error": "first message must be 'register'" }),
+                            &json!({ "error": "first message must be 'register'" }),
                         )
                         .await?;
                     return Ok(());
@@ -59,7 +59,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                 state.db.update_server_heartbeat(&server_slug).await.ok();
 
                 channel
-                    .send_response(msg.id, "register", json!({ "status": "ok" }))
+                    .send_response(msg.id, "register", &json!({ "status": "ok" }))
                     .await?;
 
                 info!(server = %server_slug, version = %version, "Agent 接続完了");
@@ -87,12 +87,12 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             if let Some(pv) = p["agent_version"].as_str() {
                                                 state.db.update_server_versions(slug, Some(pv), None).await.ok();
                                             }
-                                            channel.send_response(m.id, "heartbeat", json!({"status": "ok"})).await?;
+                                            channel.send_response(m.id, "heartbeat", &json!({"status": "ok"})).await?;
                                         }
                                         "alert" => {
                                             // Agent からのアラート → DB に保存
                                             handle_agent_alert(&state, &p).await;
-                                            channel.send_response(m.id, "alert", json!({"status": "ok"})).await?;
+                                            channel.send_response(m.id, "alert", &json!({"status": "ok"})).await?;
                                         }
                                         "deploy_result" | "restart_result" | "status_result" => {
                                             // Agent からの応答 → pending_responses に返す
@@ -134,7 +134,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         "payload": payload,
                                     });
 
-                                    if let Err(e) = channel.send_event(&method, cmd_payload).await {
+                                    if let Err(e) = channel.send_event(&method, &cmd_payload).await {
                                         error!(error = %e, method = %method, "Agent へのコマンド送信失敗");
                                         // 応答待ちがあればエラーを返す
                                         if let Some(tx) = pending_responses.remove(&req_id) {

--- a/crates/fleetflow-controlplane/src/handlers/build.rs
+++ b/crates/fleetflow-controlplane/src/handlers/build.rs
@@ -38,7 +38,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "submit",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -49,7 +49,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "submit",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -71,7 +71,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "submit",
-                                        json!({ "error": "`git_url` required" }),
+                                        &json!({ "error": "`git_url` required" }),
                                     )
                                     .await?;
                                 continue;
@@ -82,7 +82,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "submit",
-                                        json!({ "error": format!("invalid kind: {}", kind) }),
+                                        &json!({ "error": format!("invalid kind: {}", kind) }),
                                     )
                                     .await?;
                                 continue;
@@ -127,7 +127,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "submit",
-                                            json!({ "build_job": created }),
+                                            &json!({ "build_job": created }),
                                         )
                                         .await?;
                                 }
@@ -137,7 +137,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "submit",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -154,7 +154,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -165,7 +165,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -179,7 +179,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "build_jobs": jobs }),
+                                            &json!({ "build_jobs": jobs }),
                                         )
                                         .await?;
                                 }
@@ -189,7 +189,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -205,7 +205,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "get",
-                                        json!({ "error": "`job_id` required" }),
+                                        &json!({ "error": "`job_id` required" }),
                                     )
                                     .await?;
                                 continue;
@@ -219,7 +219,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -230,7 +230,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -250,7 +250,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "get",
-                                                json!({ "error": "job does not belong to this tenant" }),
+                                                &json!({ "error": "job does not belong to this tenant" }),
                                             )
                                             .await?;
                                         continue;
@@ -259,7 +259,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "build_job": job }),
+                                            &json!({ "build_job": job }),
                                         )
                                         .await?;
                                 }
@@ -268,7 +268,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": "build job not found" }),
+                                            &json!({ "error": "build job not found" }),
                                         )
                                         .await?;
                                 }
@@ -278,7 +278,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -294,7 +294,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "cancel",
-                                        json!({ "error": "`job_id` required" }),
+                                        &json!({ "error": "`job_id` required" }),
                                     )
                                     .await?;
                                 continue;
@@ -307,7 +307,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "cancel",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -318,7 +318,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "cancel",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -337,7 +337,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "cancel",
-                                                json!({ "error": "job does not belong to this tenant" }),
+                                                &json!({ "error": "job does not belong to this tenant" }),
                                             )
                                             .await?;
                                         continue;
@@ -351,7 +351,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "cancel",
-                                                json!({ "error": format!("cannot cancel job in state: {}", job.state) }),
+                                                &json!({ "error": format!("cannot cancel job in state: {}", job.state) }),
                                             )
                                             .await?;
                                         continue;
@@ -367,7 +367,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "cancel",
-                                                    json!({ "status": "cancelled" }),
+                                                    &json!({ "status": "cancelled" }),
                                                 )
                                                 .await?;
                                         }
@@ -377,7 +377,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "cancel",
-                                                    json!({ "error": e.to_string() }),
+                                                    &json!({ "error": e.to_string() }),
                                                 )
                                                 .await?;
                                         }
@@ -388,7 +388,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "cancel",
-                                            json!({ "error": "build job not found" }),
+                                            &json!({ "error": "build job not found" }),
                                         )
                                         .await?;
                                 }
@@ -398,7 +398,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "cancel",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -409,7 +409,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     other,
-                                    json!({ "error": format!("unknown method: {}", other) }),
+                                    &json!({ "error": format!("unknown method: {}", other) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/container.rs
+++ b/crates/fleetflow-controlplane/src/handlers/container.rs
@@ -16,7 +16,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                 loop {
                     let msg = channel.recv().await?;
                     let payload: serde_json::Value =
-                        serde_json::from_str(&msg.payload).unwrap_or_default();
+                        serde_json::from_slice(&msg.payload).unwrap_or_default();
 
                     match msg.method.as_str() {
                         "start" => {
@@ -28,7 +28,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "start",
-                                        json!({ "error": "container_name is required" }),
+                                        &json!({ "error": "container_name is required" }),
                                     )
                                     .await?;
                                 continue;
@@ -39,7 +39,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 Ok(()) => json!({ "status": "started", "container_name": container_name }),
                                 Err(e) => json!({ "error": e.to_string() }),
                             };
-                            channel.send_response(msg.id, "start", resp).await?;
+                            channel.send_response(msg.id, "start", &resp).await?;
                         }
                         "stop" => {
                             let container_name =
@@ -50,7 +50,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "stop",
-                                        json!({ "error": "container_name is required" }),
+                                        &json!({ "error": "container_name is required" }),
                                     )
                                     .await?;
                                 continue;
@@ -61,7 +61,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 Ok(()) => json!({ "status": "stopped", "container_name": container_name }),
                                 Err(e) => json!({ "error": e.to_string() }),
                             };
-                            channel.send_response(msg.id, "stop", resp).await?;
+                            channel.send_response(msg.id, "stop", &resp).await?;
                         }
                         "restart" => {
                             let container_name =
@@ -72,7 +72,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "restart",
-                                        json!({ "error": "container_name is required" }),
+                                        &json!({ "error": "container_name is required" }),
                                     )
                                     .await?;
                                 continue;
@@ -83,7 +83,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 Ok(()) => json!({ "status": "restarted", "container_name": container_name }),
                                 Err(e) => json!({ "error": e.to_string() }),
                             };
-                            channel.send_response(msg.id, "restart", resp).await?;
+                            channel.send_response(msg.id, "restart", &resp).await?;
                         }
                         "logs" => {
                             // TODO: Event push でログストリーミング
@@ -97,7 +97,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 Ok(logs) => json!({ "logs": logs, "container_name": container_name }),
                                 Err(e) => json!({ "error": e.to_string() }),
                             };
-                            channel.send_response(msg.id, "logs", resp).await?;
+                            channel.send_response(msg.id, "logs", &resp).await?;
                         }
                         "exec" => {
                             // TODO: Phase 2 — Raw bytes で stdin/stdout 双方向通信
@@ -105,7 +105,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     "exec",
-                                    json!({ "error": "exec は Phase 2 で実装予定" }),
+                                    &json!({ "error": "exec は Phase 2 で実装予定" }),
                                 )
                                 .await?;
                         }
@@ -115,7 +115,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/cost.rs
+++ b/crates/fleetflow-controlplane/src/handlers/cost.rs
@@ -36,7 +36,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "record",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -47,7 +47,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "record",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -74,7 +74,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "record",
-                                            json!({ "cost_entry": created }),
+                                            &json!({ "cost_entry": created }),
                                         )
                                         .await?;
                                 }
@@ -84,7 +84,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "record",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -100,7 +100,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "entries": entries }),
+                                            &json!({ "entries": entries }),
                                         )
                                         .await?;
                                 }
@@ -110,7 +110,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -126,7 +126,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "summary",
-                                            json!({ "summaries": summaries }),
+                                            &json!({ "summaries": summaries }),
                                         )
                                         .await?;
                                 }
@@ -136,7 +136,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "summary",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -148,7 +148,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/deploy.rs
+++ b/crates/fleetflow-controlplane/src/handlers/deploy.rs
@@ -35,7 +35,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "run",
-                                                    json!({ "error": format!("missing required field: {}", $name) }),
+                                                    &json!({ "error": format!("missing required field: {}", $name) }),
                                                 )
                                                 .await?;
                                             continue;
@@ -57,7 +57,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -68,7 +68,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -87,7 +87,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": "project not found" }),
+                                            &json!({ "error": "project not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -98,7 +98,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -115,7 +115,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "run",
-                                                json!({ "error": e.to_string() }),
+                                                &json!({ "error": e.to_string() }),
                                             )
                                             .await?;
                                         continue;
@@ -132,7 +132,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": format!("server '{}' not found", server_slug) }),
+                                            &json!({ "error": format!("server '{}' not found", server_slug) }),
                                         )
                                         .await?;
                                     continue;
@@ -147,7 +147,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": "tenant has no id" }),
+                                            &json!({ "error": "tenant has no id" }),
                                         )
                                         .await?;
                                     continue;
@@ -160,7 +160,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": "project has no id" }),
+                                            &json!({ "error": "project has no id" }),
                                         )
                                         .await?;
                                     continue;
@@ -188,7 +188,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "run",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -242,7 +242,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     "run",
-                                    json!({
+                                    &json!({
                                         "deployment_id": created.id.map(|id| format!("{id:?}")),
                                         "status": status,
                                         "log": log,
@@ -261,7 +261,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "history",
-                                            json!({ "deployments": deployments }),
+                                            &json!({ "deployments": deployments }),
                                         )
                                         .await?;
                                 }
@@ -271,7 +271,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "history",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -292,7 +292,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "execute",
-                                                json!({ "error": format!("invalid request: {}", e) }),
+                                                &json!({ "error": format!("invalid request: {}", e) }),
                                             )
                                             .await?;
                                         continue;
@@ -308,7 +308,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "execute",
-                                                json!({ "error": "tenant not found" }),
+                                                &json!({ "error": "tenant not found" }),
                                             )
                                             .await?;
                                         continue;
@@ -319,7 +319,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "execute",
-                                                json!({ "error": e.to_string() }),
+                                                &json!({ "error": e.to_string() }),
                                             )
                                             .await?;
                                         continue;
@@ -337,7 +337,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "execute",
-                                            json!({ "error": "project not found" }),
+                                            &json!({ "error": "project not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -348,7 +348,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "execute",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -363,7 +363,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "execute",
-                                            json!({ "error": "tenant has no id" }),
+                                            &json!({ "error": "tenant has no id" }),
                                         )
                                         .await?;
                                     continue;
@@ -376,7 +376,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "execute",
-                                            json!({ "error": "project has no id" }),
+                                            &json!({ "error": "project has no id" }),
                                         )
                                         .await?;
                                     continue;
@@ -407,7 +407,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "execute",
-                                                json!({ "error": e.to_string() }),
+                                                &json!({ "error": e.to_string() }),
                                             )
                                             .await?;
                                         continue;
@@ -423,7 +423,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "execute",
-                                            json!({ "error": format!("Docker connection failed: {}", e) }),
+                                            &json!({ "error": format!("Docker connection failed: {}", e) }),
                                         )
                                         .await?;
                                     continue;
@@ -477,7 +477,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     "execute",
-                                    json!({
+                                    &json!({
                                         "deployment_id": created.id.map(|id| format!("{id:?}")),
                                         "status": status,
                                         "log": log_str,
@@ -491,7 +491,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/dns.rs
+++ b/crates/fleetflow-controlplane/src/handlers/dns.rs
@@ -35,7 +35,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -46,7 +46,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -59,7 +59,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": "tenant has no id" }),
+                                            &json!({ "error": "tenant has no id" }),
                                         )
                                         .await?;
                                     continue;
@@ -120,7 +120,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "dns_record": created }),
+                                            &json!({ "dns_record": created }),
                                         )
                                         .await?;
                                 }
@@ -130,7 +130,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -145,7 +145,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "dns_records": records }),
+                                            &json!({ "dns_records": records }),
                                         )
                                         .await?;
                                 }
@@ -155,7 +155,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -185,7 +185,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "delete",
-                                            json!({ "deleted": deleted }),
+                                            &json!({ "deleted": deleted }),
                                         )
                                         .await?;
                                 }
@@ -195,7 +195,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "delete",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -212,7 +212,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "sync",
-                                                json!({ "error": format!("Cloudflare 設定エラー: {e}") }),
+                                                &json!({ "error": format!("Cloudflare 設定エラー: {e}") }),
                                             )
                                             .await?;
                                         continue;
@@ -232,7 +232,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "sync",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -252,7 +252,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "sync",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -269,7 +269,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "sync",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -325,7 +325,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     "sync",
-                                    json!({
+                                    &json!({
                                         "imported": imported,
                                         "cf_total": cf_records.len(),
                                         "db_total": db_records.len() + imported as usize,
@@ -340,7 +340,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/health.rs
+++ b/crates/fleetflow-controlplane/src/handlers/health.rs
@@ -33,7 +33,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "overview",
-                                            json!({
+                                            &json!({
                                                 "tenant_slug": tenant_slug,
                                                 "project_count": projects.len(),
                                                 "server_count": servers.len(),
@@ -48,7 +48,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "overview",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -60,7 +60,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/project.rs
+++ b/crates/fleetflow-controlplane/src/handlers/project.rs
@@ -33,7 +33,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -44,7 +44,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -70,7 +70,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "project": created }),
+                                            &json!({ "project": created }),
                                         )
                                         .await?;
                                 }
@@ -80,7 +80,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -93,7 +93,11 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             match state.db.get_project_by_slug(tenant_slug, slug).await {
                                 Ok(Some(project)) => {
                                     channel
-                                        .send_response(msg.id, "get", json!({ "project": project }))
+                                        .send_response(
+                                            msg.id,
+                                            "get",
+                                            &json!({ "project": project }),
+                                        )
                                         .await?;
                                 }
                                 Ok(None) => {
@@ -101,7 +105,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": "project not found" }),
+                                            &json!({ "error": "project not found" }),
                                         )
                                         .await?;
                                 }
@@ -111,7 +115,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -126,7 +130,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "projects": projects }),
+                                            &json!({ "projects": projects }),
                                         )
                                         .await?;
                                 }
@@ -136,7 +140,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -149,7 +153,11 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             match state.db.delete_project(tenant_slug, slug).await {
                                 Ok(_) => {
                                     channel
-                                        .send_response(msg.id, "delete", json!({ "deleted": true }))
+                                        .send_response(
+                                            msg.id,
+                                            "delete",
+                                            &json!({ "deleted": true }),
+                                        )
                                         .await?;
                                 }
                                 Err(e) => {
@@ -158,7 +166,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "delete",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -170,7 +178,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -29,7 +29,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "servers": servers }),
+                                            &json!({ "servers": servers }),
                                         )
                                         .await?;
                                 }
@@ -39,7 +39,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -56,7 +56,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "register",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -67,7 +67,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "register",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -109,7 +109,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "register",
-                                            json!({ "server": created }),
+                                            &json!({ "server": created }),
                                         )
                                         .await?;
                                 }
@@ -119,7 +119,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "register",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -143,7 +143,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             match result {
                                 Ok(()) => {
                                     channel
-                                        .send_response(msg.id, "heartbeat", json!({ "ack": true }))
+                                        .send_response(msg.id, "heartbeat", &json!({ "ack": true }))
                                         .await?;
                                 }
                                 Err(e) => {
@@ -152,7 +152,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "heartbeat",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -168,7 +168,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "check-all",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -183,7 +183,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "check-all",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -226,7 +226,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "check-all",
-                                            json!({ "updated": count, "results": results }),
+                                            &json!({ "updated": count, "results": results }),
                                         )
                                         .await?;
                                 }
@@ -236,7 +236,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "check-all",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -251,7 +251,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "server": server }),
+                                            &json!({ "server": server }),
                                         )
                                         .await?;
                                 }
@@ -260,7 +260,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": "server not found" }),
+                                            &json!({ "error": "server not found" }),
                                         )
                                         .await?;
                                 }
@@ -270,7 +270,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -285,7 +285,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": "server provider not configured" }),
+                                            &json!({ "error": "server provider not configured" }),
                                         )
                                         .await?;
                                     continue;
@@ -300,7 +300,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -311,7 +311,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -326,7 +326,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "create",
-                                                json!({ "error": format!("invalid request: {}", e) }),
+                                                &json!({ "error": format!("invalid request: {}", e) }),
                                             )
                                             .await?;
                                         continue;
@@ -344,7 +344,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -367,7 +367,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({
+                                            &json!({
                                                 "error": "server created but no IP address assigned",
                                                 "cloud": spec,
                                             }),
@@ -410,7 +410,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({
+                                            &json!({
                                                 "server": registered,
                                                 "cloud": spec,
                                             }),
@@ -424,7 +424,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({
+                                            &json!({
                                                 "error": e.to_string(),
                                                 "cloud": spec,
                                                 "warning": "クラウドにはサーバーが作成されています"
@@ -452,7 +452,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "delete",
-                                                    json!({ "error": e.to_string() }),
+                                                    &json!({ "error": e.to_string() }),
                                                 )
                                                 .await?;
                                             continue;
@@ -463,7 +463,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                             .send_response(
                                                 msg.id,
                                                 "delete",
-                                                json!({ "error": "server provider not configured (cannot delete from cloud)" }),
+                                                &json!({ "error": "server provider not configured (cannot delete from cloud)" }),
                                             )
                                             .await?;
                                         continue;
@@ -478,7 +478,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "delete",
-                                            json!({ "deleted": slug }),
+                                            &json!({ "deleted": slug }),
                                         )
                                         .await?;
                                 }
@@ -488,7 +488,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "delete",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -505,7 +505,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "power-on",
-                                                    json!({ "ok": true }),
+                                                    &json!({ "ok": true }),
                                                 )
                                                 .await?;
                                         }
@@ -515,7 +515,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "power-on",
-                                                    json!({ "error": e.to_string() }),
+                                                    &json!({ "error": e.to_string() }),
                                                 )
                                                 .await?;
                                         }
@@ -526,7 +526,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "power-on",
-                                            json!({ "error": "server provider not configured" }),
+                                            &json!({ "error": "server provider not configured" }),
                                         )
                                         .await?;
                                 }
@@ -543,7 +543,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "power-off",
-                                                    json!({ "ok": true }),
+                                                    &json!({ "ok": true }),
                                                 )
                                                 .await?;
                                         }
@@ -553,7 +553,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                                 .send_response(
                                                     msg.id,
                                                     "power-off",
-                                                    json!({ "error": e.to_string() }),
+                                                    &json!({ "error": e.to_string() }),
                                                 )
                                                 .await?;
                                         }
@@ -564,7 +564,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "power-off",
-                                            json!({ "error": "server provider not configured" }),
+                                            &json!({ "error": "server provider not configured" }),
                                         )
                                         .await?;
                                 }
@@ -590,7 +590,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "alert",
-                                            json!({ "error": "server not found" }),
+                                            &json!({ "error": "server not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -601,7 +601,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "alert",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -633,7 +633,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "alert",
-                                            json!({ "ack": true }),
+                                            &json!({ "ack": true }),
                                         )
                                         .await?;
                                 }
@@ -643,7 +643,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "alert",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -666,7 +666,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "alert_resolve",
-                                            json!({ "ack": true }),
+                                            &json!({ "ack": true }),
                                         )
                                         .await?;
                                 }
@@ -676,7 +676,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "alert_resolve",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -691,7 +691,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "ping",
-                                            json!({
+                                            &json!({
                                                 "hostname": result.hostname,
                                                 "reachable": result.reachable,
                                                 "latency_ms": result.latency_ms,
@@ -706,7 +706,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "ping",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -718,7 +718,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/service.rs
+++ b/crates/fleetflow-controlplane/src/handlers/service.rs
@@ -30,7 +30,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "services": services }),
+                                            &json!({ "services": services }),
                                         )
                                         .await?;
                                 }
@@ -40,7 +40,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -52,7 +52,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/stage.rs
+++ b/crates/fleetflow-controlplane/src/handlers/stage.rs
@@ -41,7 +41,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "stage": created }),
+                                            &json!({ "stage": created }),
                                         )
                                         .await?;
                                 }
@@ -51,7 +51,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -65,7 +65,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             match state.db.list_stages_by_project(&project_id).await {
                                 Ok(stages) => {
                                     channel
-                                        .send_response(msg.id, "list", json!({ "stages": stages }))
+                                        .send_response(msg.id, "list", &json!({ "stages": stages }))
                                         .await?;
                                 }
                                 Err(e) => {
@@ -74,7 +74,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -94,7 +94,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list_across_projects",
-                                            json!({ "stages": stages }),
+                                            &json!({ "stages": stages }),
                                         )
                                         .await?;
                                 }
@@ -104,7 +104,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list_across_projects",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -130,7 +130,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": format!("`{}` required", name) }),
+                                            &json!({ "error": format!("`{}` required", name) }),
                                         )
                                         .await?;
                                     continue;
@@ -155,7 +155,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": "`services` must be a non-empty array of { slug, image }" }),
+                                            &json!({ "error": "`services` must be a non-empty array of { slug, image }" }),
                                         )
                                         .await?;
                                     continue;
@@ -170,7 +170,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -181,7 +181,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -197,7 +197,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({
+                                            &json!({
                                                 "error": format!("server `{}` not found", server_slug)
                                             }),
                                         )
@@ -210,7 +210,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -221,7 +221,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "adopt",
-                                        json!({ "error": "server does not belong to this tenant" }),
+                                        &json!({ "error": "server does not belong to this tenant" }),
                                     )
                                     .await?;
                                 continue;
@@ -253,7 +253,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "outcome": outcome }),
+                                            &json!({ "outcome": outcome }),
                                         )
                                         .await?;
                                 }
@@ -263,7 +263,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -275,7 +275,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/tenant.rs
+++ b/crates/fleetflow-controlplane/src/handlers/tenant.rs
@@ -24,7 +24,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             match state.db.get_tenant_by_slug(slug).await {
                                 Ok(Some(tenant)) => {
                                     channel
-                                        .send_response(msg.id, "get", json!({ "tenant": tenant }))
+                                        .send_response(msg.id, "get", &json!({ "tenant": tenant }))
                                         .await?;
                                 }
                                 Ok(None) => {
@@ -32,7 +32,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                 }
@@ -42,7 +42,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "get",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -77,7 +77,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "tenant": created }),
+                                            &json!({ "tenant": created }),
                                         )
                                         .await?;
                                 }
@@ -87,7 +87,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "create",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -96,7 +96,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                         "list" => match state.db.list_tenants().await {
                             Ok(tenants) => {
                                 channel
-                                    .send_response(msg.id, "list", json!({ "tenants": tenants }))
+                                    .send_response(msg.id, "list", &json!({ "tenants": tenants }))
                                     .await?;
                             }
                             Err(e) => {
@@ -105,7 +105,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "list",
-                                        json!({ "error": e.to_string() }),
+                                        &json!({ "error": e.to_string() }),
                                     )
                                     .await?;
                             }
@@ -116,7 +116,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     method,
-                                    json!({ "error": format!("unknown method: {}", method) }),
+                                    &json!({ "error": format!("unknown method: {}", method) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/src/handlers/volume.rs
+++ b/crates/fleetflow-controlplane/src/handlers/volume.rs
@@ -36,7 +36,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -47,7 +47,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -61,7 +61,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "volumes": volumes }),
+                                            &json!({ "volumes": volumes }),
                                         )
                                         .await?;
                                 }
@@ -71,7 +71,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "list",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -98,7 +98,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": format!("`{}` required", name) }),
+                                            &json!({ "error": format!("`{}` required", name) }),
                                         )
                                         .await?;
                                     continue;
@@ -112,7 +112,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": "tenant not found" }),
+                                            &json!({ "error": "tenant not found" }),
                                         )
                                         .await?;
                                     continue;
@@ -123,7 +123,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -138,7 +138,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({
+                                            &json!({
                                                 "error": format!("server `{}` not found", server_slug)
                                             }),
                                         )
@@ -151,7 +151,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                     continue;
@@ -162,7 +162,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .send_response(
                                         msg.id,
                                         "adopt",
-                                        json!({
+                                        &json!({
                                             "error": "server does not belong to this tenant"
                                         }),
                                     )
@@ -187,7 +187,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "volume": volume }),
+                                            &json!({ "volume": volume }),
                                         )
                                         .await?;
                                 }
@@ -197,7 +197,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         .send_response(
                                             msg.id,
                                             "adopt",
-                                            json!({ "error": e.to_string() }),
+                                            &json!({ "error": e.to_string() }),
                                         )
                                         .await?;
                                 }
@@ -208,7 +208,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 .send_response(
                                     msg.id,
                                     other,
-                                    json!({ "error": format!("unknown method: {}", other) }),
+                                    &json!({ "error": format!("unknown method: {}", other) }),
                                 )
                                 .await?;
                         }

--- a/crates/fleetflow-controlplane/tests/channel_integration.rs
+++ b/crates/fleetflow-controlplane/tests/channel_integration.rs
@@ -69,13 +69,13 @@ async fn test_tenant_get_and_list() -> anyhow::Result<()> {
     let channel = client.open_channel("tenant").await?;
 
     // List tenants (should be empty initially)
-    let resp = channel.request("list", json!({})).await?;
+    let resp: serde_json::Value = channel.request("list", &json!({})).await?;
     let tenants = resp["tenants"].as_array().unwrap();
     assert!(tenants.is_empty(), "初期状態ではテナントは空");
 
     // Get non-existent tenant
-    let resp = channel
-        .request("get", json!({ "slug": "nonexistent" }))
+    let resp: serde_json::Value = channel
+        .request("get", &json!({ "slug": "nonexistent" }))
         .await?;
     assert!(
         resp.get("error").is_some() || resp.get("tenant").is_none(),
@@ -96,10 +96,10 @@ async fn test_project_create_and_list() -> anyhow::Result<()> {
     let channel = client.open_channel("project").await?;
 
     // Create a project
-    let resp = channel
+    let resp: serde_json::Value = channel
         .request(
             "create",
-            json!({
+            &json!({
                 "tenant_slug": "test-org",
                 "name": "my-project",
                 "description": "Test project"
@@ -113,8 +113,8 @@ async fn test_project_create_and_list() -> anyhow::Result<()> {
     }
 
     // List projects
-    let resp = channel
-        .request("list", json!({ "tenant_slug": "test-org" }))
+    let resp: serde_json::Value = channel
+        .request("list", &json!({ "tenant_slug": "test-org" }))
         .await?;
     assert!(resp.get("projects").is_some(), "projects キーが存在する");
 
@@ -131,7 +131,7 @@ async fn test_health_overview() -> anyhow::Result<()> {
 
     let channel = client.open_channel("health").await?;
 
-    let resp = channel.request("overview", json!({})).await?;
+    let resp: serde_json::Value = channel.request("overview", &json!({})).await?;
 
     // Health overview returns project_count and server_count
     assert!(
@@ -153,15 +153,15 @@ async fn test_server_list_and_register() -> anyhow::Result<()> {
     let channel = client.open_channel("server").await?;
 
     // List servers (empty)
-    let resp = channel.request("list", json!({})).await?;
+    let resp: serde_json::Value = channel.request("list", &json!({})).await?;
     let servers = resp["servers"].as_array().unwrap();
     assert!(servers.is_empty(), "初期状態ではサーバーは空");
 
     // Register a server
-    let resp = channel
+    let resp: serde_json::Value = channel
         .request(
             "register",
-            json!({
+            &json!({
                 "tenant_slug": "test-org",
                 "slug": "vps-01",
                 "hostname": "test-server.local",
@@ -188,7 +188,7 @@ async fn test_unknown_method_returns_error() -> anyhow::Result<()> {
 
     let channel = client.open_channel("tenant").await?;
 
-    let resp = channel.request("nonexistent_method", json!({})).await?;
+    let resp: serde_json::Value = channel.request("nonexistent_method", &json!({})).await?;
     assert!(resp.get("error").is_some(), "不明なメソッドはエラーを返す");
 
     channel.close().await?;

--- a/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
+++ b/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
@@ -111,10 +111,10 @@ async fn test_deploy_execute_channel() -> anyhow::Result<()> {
         no_prune: true,
     };
 
-    let resp = channel
+    let resp: serde_json::Value = channel
         .request(
             "execute",
-            json!({
+            &json!({
                 "tenant_slug": "default",
                 "project_slug": "deploy-test",
                 "request": serde_json::to_value(&request)?,
@@ -149,10 +149,10 @@ async fn test_deploy_execute_with_tenant_and_project() -> anyhow::Result<()> {
 
     // テナント作成
     let tenant_ch = client.open_channel("tenant").await?;
-    let resp = tenant_ch
+    let resp: serde_json::Value = tenant_ch
         .request(
             "create",
-            json!({ "name": "Test Org", "slug": "test-deploy-org" }),
+            &json!({ "name": "Test Org", "slug": "test-deploy-org" }),
         )
         .await?;
     tenant_ch.close().await?;
@@ -165,10 +165,10 @@ async fn test_deploy_execute_with_tenant_and_project() -> anyhow::Result<()> {
 
     // プロジェクト作成
     let project_ch = client.open_channel("project").await?;
-    let resp = project_ch
+    let resp: serde_json::Value = project_ch
         .request(
             "create",
-            json!({
+            &json!({
                 "tenant_slug": "test-deploy-org",
                 "slug": "deploy-test",
                 "name": "deploy-test",
@@ -194,10 +194,10 @@ async fn test_deploy_execute_with_tenant_and_project() -> anyhow::Result<()> {
         no_prune: true,
     };
 
-    let resp = deploy_ch
+    let resp: serde_json::Value = deploy_ch
         .request(
             "execute",
-            json!({
+            &json!({
                 "tenant_slug": "test-deploy-org",
                 "project_slug": "deploy-test",
                 "request": serde_json::to_value(&request)?,

--- a/crates/fleetflow-controlplane/tests/server_crud_test.rs
+++ b/crates/fleetflow-controlplane/tests/server_crud_test.rs
@@ -64,8 +64,8 @@ async fn connect_client(port: u16) -> anyhow::Result<ProtocolClient> {
 
 async fn create_tenant(client: &ProtocolClient, slug: &str) -> anyhow::Result<()> {
     let ch = client.open_channel("tenant").await?;
-    let resp = ch
-        .request("create", json!({ "name": slug, "slug": slug }))
+    let resp: serde_json::Value = ch
+        .request("create", &json!({ "name": slug, "slug": slug }))
         .await?;
     ch.close().await?;
     assert!(resp.get("error").is_none(), "テナント作成失敗: {:?}", resp);
@@ -91,7 +91,7 @@ async fn test_server_get_not_found() -> anyhow::Result<()> {
     let client = connect_client(port).await?;
 
     let ch = client.open_channel("server").await?;
-    let resp = ch.request("get", json!({ "slug": "nonexistent" })).await?;
+    let resp: serde_json::Value = ch.request("get", &json!({ "slug": "nonexistent" })).await?;
 
     assert_eq!(resp["error"].as_str().unwrap(), "server not found");
 
@@ -110,9 +110,9 @@ async fn test_server_get_after_register() -> anyhow::Result<()> {
 
     let ch = client.open_channel("server").await?;
 
-    ch.request(
+    let _: serde_json::Value = ch.request(
         "register",
-        json!({
+        &json!({
             "tenant_slug": "get-test-org",
             "slug": "web-01",
             "provider": "manual",
@@ -123,7 +123,7 @@ async fn test_server_get_after_register() -> anyhow::Result<()> {
     )
     .await?;
 
-    let resp = ch.request("get", json!({ "slug": "web-01" })).await?;
+    let resp: serde_json::Value = ch.request("get", &json!({ "slug": "web-01" })).await?;
     assert!(resp.get("error").is_none(), "get 成功: {:?}", resp);
     assert_eq!(resp["server"]["slug"].as_str().unwrap(), "web-01");
     assert_eq!(resp["server"]["provider"].as_str().unwrap(), "manual");
@@ -144,10 +144,10 @@ async fn test_server_create_no_provider() -> anyhow::Result<()> {
     let client = connect_client(port).await?;
 
     let ch = client.open_channel("server").await?;
-    let resp = ch
+    let resp: serde_json::Value = ch
         .request(
             "create",
-            json!({
+            &json!({
                 "tenant_slug": "some-org",
                 "request": {
                     "name": "test-server",
@@ -178,10 +178,10 @@ async fn test_server_create_tenant_not_found() -> anyhow::Result<()> {
     let client = connect_client(port).await?;
 
     let ch = client.open_channel("server").await?;
-    let resp = ch
+    let resp: serde_json::Value = ch
         .request(
             "create",
-            json!({
+            &json!({
                 "tenant_slug": "nonexistent-org",
                 "request": {
                     "name": "test-server",
@@ -211,10 +211,10 @@ async fn test_server_create_success() -> anyhow::Result<()> {
     create_tenant(&client, "create-test-org").await?;
 
     let ch = client.open_channel("server").await?;
-    let resp = ch
+    let resp: serde_json::Value = ch
         .request(
             "create",
-            json!({
+            &json!({
                 "tenant_slug": "create-test-org",
                 "request": {
                     "name": "fleet-worker-01",
@@ -258,9 +258,9 @@ async fn test_server_delete_db_only() -> anyhow::Result<()> {
 
     let ch = client.open_channel("server").await?;
 
-    ch.request(
+    let _: serde_json::Value = ch.request(
         "register",
-        json!({
+        &json!({
             "tenant_slug": "delete-test-org",
             "slug": "to-delete",
             "provider": "manual",
@@ -269,11 +269,11 @@ async fn test_server_delete_db_only() -> anyhow::Result<()> {
     )
     .await?;
 
-    let resp = ch.request("delete", json!({ "slug": "to-delete" })).await?;
+    let resp: serde_json::Value = ch.request("delete", &json!({ "slug": "to-delete" })).await?;
     assert!(resp.get("error").is_none(), "delete 成功: {:?}", resp);
     assert_eq!(resp["deleted"].as_str().unwrap(), "to-delete");
 
-    let resp = ch.request("get", json!({ "slug": "to-delete" })).await?;
+    let resp: serde_json::Value = ch.request("get", &json!({ "slug": "to-delete" })).await?;
     assert_eq!(resp["error"].as_str().unwrap(), "server not found");
 
     ch.close().await?;
@@ -292,9 +292,9 @@ async fn test_server_delete_with_cloud() -> anyhow::Result<()> {
 
     let ch = client.open_channel("server").await?;
 
-    ch.request(
+    let _: serde_json::Value = ch.request(
         "register",
-        json!({
+        &json!({
             "tenant_slug": "delete-cloud-org",
             "slug": "cloud-server",
             "provider": "mock-provider",
@@ -303,10 +303,10 @@ async fn test_server_delete_with_cloud() -> anyhow::Result<()> {
     )
     .await?;
 
-    let resp = ch
+    let resp: serde_json::Value = ch
         .request(
             "delete",
-            json!({
+            &json!({
                 "slug": "cloud-server",
                 "cloud_id": "99999",
                 "with_disks": true
@@ -336,8 +336,8 @@ async fn test_server_power_on_no_provider() -> anyhow::Result<()> {
     let client = connect_client(port).await?;
 
     let ch = client.open_channel("server").await?;
-    let resp = ch
-        .request("power-on", json!({ "cloud_id": "12345" }))
+    let resp: serde_json::Value = ch
+        .request("power-on", &json!({ "cloud_id": "12345" }))
         .await?;
 
     assert_eq!(
@@ -358,8 +358,8 @@ async fn test_server_power_on_success() -> anyhow::Result<()> {
     let client = connect_client(port).await?;
 
     let ch = client.open_channel("server").await?;
-    let resp = ch
-        .request("power-on", json!({ "cloud_id": "12345" }))
+    let resp: serde_json::Value = ch
+        .request("power-on", &json!({ "cloud_id": "12345" }))
         .await?;
 
     assert!(resp.get("error").is_none(), "power-on 成功: {:?}", resp);
@@ -383,8 +383,8 @@ async fn test_server_power_off_success() -> anyhow::Result<()> {
     let client = connect_client(port).await?;
 
     let ch = client.open_channel("server").await?;
-    let resp = ch
-        .request("power-off", json!({ "cloud_id": "67890" }))
+    let resp: serde_json::Value = ch
+        .request("power-off", &json!({ "cloud_id": "67890" }))
         .await?;
 
     assert!(resp.get("error").is_none(), "power-off 成功: {:?}", resp);

--- a/crates/fleetflow-mcp/src/cp.rs
+++ b/crates/fleetflow-mcp/src/cp.rs
@@ -69,8 +69,8 @@ pub async fn request(
         .await
         .with_context(|| format!("チャネル '{}' オープン失敗", channel_name))?;
 
-    let resp = channel
-        .request(method, payload)
+    let resp: Value = channel
+        .request(method, &payload)
         .await
         .with_context(|| format!("{}.{} リクエスト失敗", channel_name, method))?;
 

--- a/crates/fleetflow/src/commands/cp_client.rs
+++ b/crates/fleetflow/src/commands/cp_client.rs
@@ -66,8 +66,8 @@ pub async fn request(
         .await
         .with_context(|| format!("チャネル '{}' オープン失敗", channel_name))?;
 
-    let resp = channel
-        .request(method, payload)
+    let resp: Value = channel
+        .request(method, &payload)
         .await
         .with_context(|| format!("{}.{} リクエスト失敗", channel_name, method))?;
 


### PR DESCRIPTION
## ⚠️ DRAFT — Production fleetflowd を同時に v0.4.1 で rebuild + deploy するまで merge 厳禁

unison main HEAD (\`6a37611\`, v0.4.1) を取り込み、USN-2 / USN-3 の breaking API 変更に追従する。

## Why DRAFT

USN-2 の breaking 変更で **wire payload 型が \`String\` → \`Vec<u8>\` に変わった**ため、新 client (本 PR) を旧 fleetflowd (production v0.14.2 build) に向けると timeout する:

\`\`\`
$ fleet cp tenant status   # 本 PR の CLI、production endpoint
Error: tenant.get リクエスト失敗
Caused by: Timeout error
\`\`\`

production fleetflowd を本 PR と同 unison rev で **同時に rebuild + deploy** する必要がある。

## 変更内容

### API migration (231 sites across 17 src + 3 test files)

- \`.request(method, payload)\` → \`.request(method, &payload)\` (with \`: Value\` 型注釈)
- \`.send_response(id, method, body)\` → \`.send_response(id, method, &body)\`
- \`.send_event(method, body)\` → \`.send_event(method, &body)\`
- \`serde_json::from_str(&msg.payload)\` → \`from_slice(&msg.payload)\`

bulk transformation は AST-aware Python script (paren balance + trailing comma 対応) で実行。詳細は航跡 #03 メモ参照。

### Cargo.toml

\`\`\`diff
-unison = { git = \"...\", rev = \"f3542df\" }
+unison = { git = \"...\", rev = \"6a37611\" }
\`\`\`

## Rollout 手順

1. **production VPS で fleetflowd を v0.4.1 build に置き換え**:
   - Mac で \`cargo zigbuild --target x86_64-unknown-linux-gnu --release\`
   - 旧 binary を \`.bak-YYYYMMDD\` 退避
   - 新 binary を scp + swap、\`systemctl restart fleetflowd\`
   - \`journalctl -u fleetflowd\` で起動確認
2. local CLI 用 fleet binary も本 PR rev で rebuild
3. smoke test: \`fleet cp tenant status\` against production
4. green になったら本 PR を **ready for review** → merge

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` (all green, including 3 migrated test files)
- [x] \`cargo install --path crates/fleetflow --force\` succeeds
- [ ] **production smoke** — production fleetflowd を v0.4.1 build + deploy した後
- [ ] CI 全 green

## 関連

- upstream: chronista-club/unison main (v0.4.1) = USN-2 + USN-3 + DNS/IPv4
- precursor: fleetflow #144 (DNS/IPv4 only, fd33f82-based unison v0.3.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)