### PR TITLE
ci: install protoc (unison v0.4+ buffa crate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: protoc のインストール (unison v0.4+ buffa crate 用)
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: mise のインストール
         uses: jdx/mise-action@v2
         with:
@@ -58,6 +64,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: protoc のインストール (unison v0.4+ buffa crate 用)
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: mise のインストール
         uses: jdx/mise-action@v2
 
@@ -83,6 +95,12 @@ jobs:
     needs: fast-tests
     steps:
       - uses: actions/checkout@v4
+
+      - name: protoc のインストール (unison v0.4+ buffa crate 用)
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: mise のインストール
         uses: jdx/mise-action@v2
@@ -111,6 +129,12 @@ jobs:
     needs: fast-tests
     steps:
       - uses: actions/checkout@v4
+
+      - name: protoc のインストール (unison v0.4+ buffa crate 用)
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary

unison v0.4.0 (USN-2/3) で **buffa crate (Protocol Buffers)** を build dependency に取り込んだため、CI runner に \`protoc\` がないと unison の build.rs が失敗する。

PR #145 (unison rev bump) merge 後、後続 PR (#146, #150) が以下のエラーで CI fail していた:

\`\`\`
Error: "failed to run protoc (protoc): No such file or directory (os error 2)"
error: failed to run custom build command for 'unison v0.4.1 ...'
\`\`\`

## Fix

すべての job に \`arduino/setup-protoc@v3\` step を追加 (Linux/macOS 両対応):

* \`fast-tests\` (clippy / fmt-check / test)
* \`security\` (cargo audit)
* \`docker-tests\` (Docker integration)
* \`coverage\` (llvm-cov)

protoc version は **27.x** (Ubuntu/macOS 標準パッケージより新しい安定版)。

## Test plan

- [x] CI 全 job 再走 → 全 green
- [x] PR #150 等の merge も unblock される

🤖 Generated with [Claude Code](https://claude.com/claude-code)