### PR TITLE
feat(server): add lifecycle / infra metadata fields (single-table model)

### DIFF
--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -1475,6 +1475,42 @@ DEFINE FIELD IF NOT EXISTS scheduling ON server TYPE option<string> DEFAULT 'sch
 -- FSC-26 Phase B-2: server → worker_pool 参照
 DEFINE FIELD IF NOT EXISTS pool_id ON server TYPE option<record<worker_pool>>;
 
+-- Server lifecycle / infra metadata (single-table model, additive)
+-- 全 field 可変、agent / controller / user CLI が役割ごとに書き込む
+-- 'running' | 'cordoned' | 'decommissioned' — desired_state は user の意図、status は observed (heartbeat 起源)
+DEFINE FIELD IF NOT EXISTS desired_state ON server TYPE option<string> DEFAULT 'running';
+DEFINE FIELD IF NOT EXISTS purpose ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS owner ON server TYPE option<string>;
+
+-- Sakura cloud infrastructure metadata (provisioning controller が書き込み)
+DEFINE FIELD IF NOT EXISTS sakura ON server TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS sakura.server_id ON server TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS sakura.disk_id ON server TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS sakura.archive_id ON server TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS sakura.zone ON server TYPE option<string>;
+
+-- Tailscale tailnet metadata (provisioning controller が書き込み)
+DEFINE FIELD IF NOT EXISTS tailscale ON server TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS tailscale.hostname ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tailscale.tailnet_ip ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tailscale.node_id ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tailscale.joined_at ON server TYPE option<datetime>;
+
+-- DNS / public network metadata (Cloudflare 等の外部 DNS)
+DEFINE FIELD IF NOT EXISTS dns ON server TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS dns.fqdn ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS dns.cloudflare_record_id ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS dns.public_ipv4 ON server TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS dns.public_ipv6 ON server TYPE option<string>;
+
+-- Lifecycle audit (immutable once set)
+-- replaced_from は graceful re-spawn 時に旧 record を指す (chain で履歴追える)
+DEFINE FIELD IF NOT EXISTS lifecycle ON server TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS lifecycle.spawned_at ON server TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS lifecycle.last_replaced_at ON server TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS lifecycle.decommissioned_at ON server TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS lifecycle.replaced_from ON server TYPE option<record<server>>;
+
 DEFINE FIELD IF NOT EXISTS created_at ON server TYPE option<datetime> DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS updated_at ON server TYPE option<datetime> DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS idx_server_tenant_slug ON server FIELDS tenant, slug UNIQUE;
@@ -1751,6 +1787,13 @@ mod tests {
             allocated: None,
             scheduling: None,
             pool_id: None,
+            desired_state: None,
+            purpose: None,
+            owner: None,
+            sakura: None,
+            tailscale: None,
+            dns: None,
+            lifecycle: None,
             created_at: None,
             updated_at: None,
         };
@@ -1824,6 +1867,13 @@ mod tests {
             }),
             scheduling: Some(scheduling_state::SCHEDULABLE.into()),
             pool_id: None,
+            desired_state: None,
+            purpose: None,
+            owner: None,
+            sakura: None,
+            tailscale: None,
+            dns: None,
+            lifecycle: None,
             created_at: None,
             updated_at: None,
         };
@@ -2014,6 +2064,13 @@ mod tests {
                 allocated: None,
                 scheduling: None,
                 pool_id: None,
+                desired_state: None,
+                purpose: None,
+                owner: None,
+                sakura: None,
+                tailscale: None,
+                dns: None,
+                lifecycle: None,
                 created_at: None,
                 updated_at: None,
             })
@@ -2104,6 +2161,13 @@ mod tests {
             allocated: None,
             scheduling: None,
             pool_id: None,
+            desired_state: None,
+            purpose: None,
+            owner: None,
+            sakura: None,
+            tailscale: None,
+            dns: None,
+            lifecycle: None,
             created_at: None,
             updated_at: None,
         })
@@ -2261,6 +2325,13 @@ mod tests {
             allocated: None,
             scheduling: None,
             pool_id: default_pool.id.clone(),
+            desired_state: None,
+            purpose: None,
+            owner: None,
+            sakura: None,
+            tailscale: None,
+            dns: None,
+            lifecycle: None,
             created_at: None,
             updated_at: None,
         };
@@ -2419,6 +2490,13 @@ mod tests {
                 allocated: None,
                 scheduling: None,
                 pool_id: None,
+                desired_state: None,
+                purpose: None,
+                owner: None,
+                sakura: None,
+                tailscale: None,
+                dns: None,
+                lifecycle: None,
                 created_at: None,
                 updated_at: None,
             })

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -99,6 +99,14 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 scheduling: None,
                                 // FSC-26 Phase B-2: migration で worker_pool:default に紐付け
                                 pool_id: None,
+                                // single-table lifecycle model
+                                desired_state: Some("running".into()),
+                                purpose: None,
+                                owner: None,
+                                sakura: None,
+                                tailscale: None,
+                                dns: None,
+                                lifecycle: None,
                                 created_at: None,
                                 updated_at: None,
                             };
@@ -400,6 +408,14 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 scheduling: None,
                                 // FSC-26 Phase B-2: migration で worker_pool:default に紐付け
                                 pool_id: None,
+                                // single-table lifecycle model
+                                desired_state: Some("running".into()),
+                                purpose: None,
+                                owner: None,
+                                sakura: None,
+                                tailscale: None,
+                                dns: None,
+                                lifecycle: None,
                                 created_at: None,
                                 updated_at: None,
                             };

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -400,6 +400,56 @@ pub mod scheduling_state {
     pub const DRAIN: &str = "drain";
 }
 
+/// Server desired state の文字列定数 (single-table lifecycle model)
+/// user の意図を表す。物理 `status` (observed) とは別。
+pub mod desired_state {
+    /// 通常稼働
+    pub const RUNNING: &str = "running";
+    /// 計画 maintenance / replace 前準備
+    pub const CORDONED: &str = "cordoned";
+    /// 廃止予定 / 廃止済み（record は残す、`status="decommissioned"` で確定）
+    pub const DECOMMISSIONED: &str = "decommissioned";
+}
+
+/// Sakura Cloud infrastructure metadata
+/// VM spawn 時に provisioning controller が書き込む
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct SakuraInfo {
+    pub server_id: Option<i64>,
+    pub disk_id: Option<i64>,
+    pub archive_id: Option<i64>,
+    pub zone: Option<String>,
+}
+
+/// Tailscale tailnet metadata
+/// `tailscale up --authkey` 完了時に書き込む
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct TailscaleInfo {
+    pub hostname: Option<String>,
+    pub tailnet_ip: Option<String>,
+    pub node_id: Option<String>,
+    pub joined_at: Option<DateTime<Utc>>,
+}
+
+/// DNS / public network metadata
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct DnsInfo {
+    pub fqdn: Option<String>,
+    pub cloudflare_record_id: Option<String>,
+    pub public_ipv4: Option<String>,
+    pub public_ipv6: Option<String>,
+}
+
+/// Lifecycle audit metadata (set once, immutable)
+/// replace は新 record + 旧 record の `replaced_from` link で表現
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SurrealValue)]
+pub struct ServerLifecycle {
+    pub spawned_at: Option<DateTime<Utc>>,
+    pub last_replaced_at: Option<DateTime<Utc>>,
+    pub decommissioned_at: Option<DateTime<Utc>>,
+    pub replaced_from: Option<RecordId>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
 pub struct Server {
     pub id: Option<RecordId>,
@@ -428,6 +478,21 @@ pub struct Server {
     /// 所属 Worker Pool (FSC-26 Phase B-2)
     /// None = 未割当（通常は migration で `worker_pool:default` が入る）
     pub pool_id: Option<RecordId>,
+    /// User-declared desired state ("running" | "cordoned" | "decommissioned")
+    /// `desired_state` モジュールの定数を使用
+    pub desired_state: Option<String>,
+    /// Human-readable purpose / role description
+    pub purpose: Option<String>,
+    /// Owner (e.g., user email or team)
+    pub owner: Option<String>,
+    /// Sakura cloud infrastructure metadata
+    pub sakura: Option<SakuraInfo>,
+    /// Tailscale tailnet metadata
+    pub tailscale: Option<TailscaleInfo>,
+    /// DNS / public network metadata
+    pub dns: Option<DnsInfo>,
+    /// Lifecycle audit (immutable once set)
+    pub lifecycle: Option<ServerLifecycle>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
 }

--- a/scripts/provision-fleet-agent.sh
+++ b/scripts/provision-fleet-agent.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# fleet-agent provisioning script
+#
+# 既に provision-worker-base.sh が完了済みの host で、fleet-agent binary を
+# 配置 + systemd unit を起こして CP に接続させる。
+#
+# 使い方:
+#   ssh root@<host> 'bash -s -- --slug <slug> --endpoint <cp-endpoint>' \
+#     < scripts/provision-fleet-agent.sh
+#
+#   # または環境変数経由:
+#   FLEET_SLUG=build-01 FLEET_CP_ENDPOINT=cp.fleetstage.cloud:4510 \
+#     bash provision-fleet-agent.sh
+#
+# 前提:
+#   - root 権限
+#   - /usr/local/bin/fleet-agent はすでに別途 scp 済み (Mac で zigbuild → scp)
+#   - Tailscale 接続済み (cp.fleetstage.cloud に到達できる)
+#
+# 冪等性: 既存 unit があれば内容更新 + restart。何度実行しても同じ結果。
+
+set -euo pipefail
+
+# ─────────────────────────────────────────
+# 引数 / 環境変数
+# ─────────────────────────────────────────
+FLEET_SLUG="${FLEET_SLUG:-}"
+FLEET_CP_ENDPOINT="${FLEET_CP_ENDPOINT:-cp.fleetstage.cloud:4510}"
+FLEET_HEARTBEAT_INTERVAL="${FLEET_HEARTBEAT_INTERVAL:-30}"
+FLEET_MONITOR_INTERVAL="${FLEET_MONITOR_INTERVAL:-30}"
+FLEET_RESTART_THRESHOLD="${FLEET_RESTART_THRESHOLD:-3}"
+FLEET_DEPLOY_BASE="${FLEET_DEPLOY_BASE:-/opt/apps}"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --slug) FLEET_SLUG="$2"; shift 2;;
+    --endpoint) FLEET_CP_ENDPOINT="$2"; shift 2;;
+    --heartbeat) FLEET_HEARTBEAT_INTERVAL="$2"; shift 2;;
+    --monitor) FLEET_MONITOR_INTERVAL="$2"; shift 2;;
+    --threshold) FLEET_RESTART_THRESHOLD="$2"; shift 2;;
+    --deploy-base) FLEET_DEPLOY_BASE="$2"; shift 2;;
+    *) echo "Unknown arg: $1" >&2; exit 1;;
+  esac
+done
+
+if [ -z "${FLEET_SLUG}" ]; then
+  echo "ERROR: --slug <name> または FLEET_SLUG 環境変数が必須" >&2
+  exit 1
+fi
+
+if [ ! -x /usr/local/bin/fleet-agent ]; then
+  echo "ERROR: /usr/local/bin/fleet-agent が見当たりません。" >&2
+  echo "       Mac で zigbuild → scp 済みか確認してください。" >&2
+  exit 1
+fi
+
+echo "=== fleet-agent provisioning ==="
+echo "  slug:      ${FLEET_SLUG}"
+echo "  endpoint:  ${FLEET_CP_ENDPOINT}"
+echo "  heartbeat: ${FLEET_HEARTBEAT_INTERVAL}s"
+echo "  monitor:   ${FLEET_MONITOR_INTERVAL}s"
+echo "  deploy:    ${FLEET_DEPLOY_BASE}"
+echo ""
+
+# ─────────────────────────────────────────
+# 1. deploy_base 用ディレクトリ
+# ─────────────────────────────────────────
+echo "[1/3] deploy_base..."
+mkdir -p "${FLEET_DEPLOY_BASE}"
+echo "  ${FLEET_DEPLOY_BASE} ready."
+
+# ─────────────────────────────────────────
+# 2. systemd unit
+# ─────────────────────────────────────────
+echo "[2/3] systemd unit..."
+cat > /etc/systemd/system/fleet-agent.service <<UNIT
+[Unit]
+Description=FleetFlow Agent
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/fleet-agent
+Environment=FLEET_AGENT_CP_ENDPOINT=${FLEET_CP_ENDPOINT}
+Environment=FLEET_AGENT_SERVER_SLUG=${FLEET_SLUG}
+Environment=FLEET_AGENT_HEARTBEAT_INTERVAL=${FLEET_HEARTBEAT_INTERVAL}
+Environment=FLEET_AGENT_MONITOR_INTERVAL=${FLEET_MONITOR_INTERVAL}
+Environment=FLEET_AGENT_RESTART_THRESHOLD=${FLEET_RESTART_THRESHOLD}
+Environment=FLEET_AGENT_DEPLOY_BASE=${FLEET_DEPLOY_BASE}
+Environment=RUST_LOG=fleet_agent=info,unison=info
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+echo "  unit installed."
+
+# ─────────────────────────────────────────
+# 3. enable + start
+# ─────────────────────────────────────────
+echo "[3/3] enable + start..."
+systemctl enable --now fleet-agent
+sleep 3
+echo ""
+echo "=== status ==="
+systemctl status fleet-agent --no-pager -l | head -10
+echo ""
+echo "=== recent logs ==="
+journalctl -u fleet-agent -n 6 --no-pager
+echo ""
+echo "次のステップ (手元 Mac から):"
+echo "  fleet cp server register --slug ${FLEET_SLUG} --provider sakura --ssh-host \$(tailscale ip -4)"
+echo "  fleet cp server list   # status: online を確認"


### PR DESCRIPTION
## Summary

Worker 管理の SSOT として `server` table を拡張。Sakura / Tailscale / DNS のインフラ metadata と lifecycle audit を single-table で統合。intent と observed を別 table で分けない k8s Node 風モデル。

## 追加 field (全 optional、breaking なし)

| group | field | 用途 |
|---|---|---|
| **declared** | `desired_state` | "running" / "cordoned" / "decommissioned" |
| | `purpose` | human-readable 用途説明 |
| | `owner` | 管理者 |
| **sakura** | `sakura.{server_id,disk_id,archive_id,zone}` | usacloud spawn 結果 |
| **tailscale** | `tailscale.{hostname,tailnet_ip,node_id,joined_at}` | tailnet join 結果 |
| **dns** | `dns.{fqdn,cloudflare_record_id,public_ipv4,public_ipv6}` | 外部 DNS metadata |
| **lifecycle** | `lifecycle.{spawned_at,last_replaced_at,decommissioned_at,replaced_from}` | audit (immutable) |

## 設計

- **single table**: intent / observed を別 table 化しない。RBAC 境界が unique user 運用ではメリットなく、k8s spec/status 分離は overengineering
- **additive のみ**: 既存 field 一切変更なし、現 server records は default 値で動作
- **冪等 reconcile loop**: controller は record 観察 → 次 action → write back (k8s Pod 同型)
- **Decommission は record を残す**: `desired_state='decommissioned'` + `lifecycle.decommissioned_at` で「廃止済み」を記録、record は履歴として残す (data 削除禁止 rule)

## Test plan

- [x] cargo test --workspace (46+ passed, 0 failed)
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt --check
- [ ] CI 全 green
- [ ] production fleetflowd redeploy 後に手動 update で existing 5 records 埋め
- [ ] 後続 `fleet workers list` PR で表示確認

## 後続

- `fleet workers list` (read-only diff 表示)
- `fleet workers spawn <slug>` (provisioning controller 自動化)
- `fleet workers replace` / `decommission` (lifecycle CLI)

🤖 Generated with Claude Code
