### PR TITLE
feat(scripts): provision-worker-base v4 — protoc + rsync + file

### DIFF
--- a/scripts/provision-worker-base.sh
+++ b/scripts/provision-worker-base.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-PROVISION_VERSION="v3"
+PROVISION_VERSION="v4"
 
 echo "=== FleetFlow Worker Base Image Provisioning (${PROVISION_VERSION}) ==="
 echo "  Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -41,6 +41,9 @@ apt-get install -y -qq \
   unzip \
   htop \
   build-essential \
+  protobuf-compiler \
+  rsync \
+  file \
   > /dev/null 2>&1
 echo "  done."
 


### PR DESCRIPTION
## Summary

Build Tier B1 worker (build-01) で fleetflowd native build をしようとして発覚した base image の不足ツールを追加。`PROVISION_VERSION` を v3 → v4 にbump。

## 追加 packages

| package | 用途 | 発覚 |
|---|---|---|
| **protobuf-compiler** | unison v0.4+ `buffa` crate の build script が `protoc` 必須 | build-01 cargo build OOM の前段、`protoc not found` で失敗 |
| **rsync** | Mac から worker に source code を sync する用途 | build-01 で `rsync` 不在発覚 (`exit 127`) |
| **file** | binary kind 確認 (`file fleetflowd` 等の dev/ops で常用) | base image に file が無いことに気付いた |

## CI も同期済

PR #151 で GitHub Actions CI に `arduino/setup-protoc@v3` を追加済 (#145 merge 後の連鎖 fail を解消)。本 PR は **base image 側の同期**。

## 既存 worker への適用

`worker-init.sh` が GitHub から最新 `provision-worker-base.sh` を **self-update** する仕組みがあるため、既存 worker は次回再起動時 (or `bash worker-init.sh` 手動実行) で v4 が適用される (冪等)。

build-01 は本日手動で `apt-get install protobuf-compiler` 済、正規 v4 適用は次回 archive 再構築 (`fleet-worker-base` archive を v4 状態で再保存) から。

## Test plan

- [x] `bash -n` syntax check
- [x] build-01 で apt-get install 同 packages 動作確認 (protoc 3.21.12 / rsync 3.2.7 / file 5.44)
- [ ] CI 全 green
- [ ] follow-up: `fleet-worker-base v4` archive を build-01 から作成 (`usacloud archive create`)

🤖 Generated with Claude Code
