### PR TITLE
feat(scripts): idle-shutdown timer for build-tier worker cost reduction

### DIFF
--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -411,29 +411,27 @@ pub async fn handle_server(cmd: &ServerCommands) -> Result<()> {
             }
             println!("{} 電源 ON 命令送信済", "✓".green());
 
-            if *wait {
-                if let Some(host) = host {
-                    println!("  SSH 待機中: {}", host.dimmed());
-                    let start = std::time::Instant::now();
-                    let timeout = std::time::Duration::from_secs(180);
-                    while start.elapsed() < timeout {
-                        let r = std::process::Command::new("nc")
-                            .args(["-zv", "-w", "3", host, "22"])
-                            .output();
-                        if let Ok(out) = r {
-                            if out.status.success() {
-                                println!(
-                                    "{} SSH 通った ({}秒)",
-                                    "✓".green(),
-                                    start.elapsed().as_secs()
-                                );
-                                return Ok(());
-                            }
-                        }
-                        std::thread::sleep(std::time::Duration::from_secs(5));
+            if *wait && let Some(host) = host {
+                println!("  SSH 待機中: {}", host.dimmed());
+                let start = std::time::Instant::now();
+                let timeout = std::time::Duration::from_secs(180);
+                while start.elapsed() < timeout {
+                    let r = std::process::Command::new("nc")
+                        .args(["-zv", "-w", "3", host, "22"])
+                        .output();
+                    if let Ok(out) = r
+                        && out.status.success()
+                    {
+                        println!(
+                            "{} SSH 通った ({}秒)",
+                            "✓".green(),
+                            start.elapsed().as_secs()
+                        );
+                        return Ok(());
                     }
-                    println!("{} SSH 待機 timeout (180s)", "⚠".yellow());
+                    std::thread::sleep(std::time::Duration::from_secs(5));
                 }
+                println!("{} SSH 待機 timeout (180s)", "⚠".yellow());
             }
         }
         ServerCommands::Shutdown { slug } => {

--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -359,6 +359,135 @@ pub async fn handle_server(cmd: &ServerCommands) -> Result<()> {
                 }
             }
         }
+        ServerCommands::Boot { slug, wait } => {
+            println!("{} {}", "Boot サーバー:".bold(), slug.cyan());
+            println!();
+
+            // CP DB から sakura.server_id を取得
+            let resp = cp_client::request(
+                &client,
+                "server",
+                "get",
+                json!({ "tenant_slug": tenant_slug, "slug": slug }),
+            )
+            .await?;
+
+            let server = match resp.get("server") {
+                Some(s) => s,
+                None => {
+                    println!("{} {}", "サーバーが見つかりません:".red(), slug);
+                    return Ok(());
+                }
+            };
+            let sakura_id = server["sakura"]["server_id"].as_i64().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "sakura.server_id が記録されていません (record の populate が必要)"
+                )
+            })?;
+            let zone = server["sakura"]["zone"].as_str().unwrap_or("tk1a");
+            let host = server["dns"]["public_ipv4"]
+                .as_str()
+                .or_else(|| server["ssh_host"].as_str());
+
+            println!(
+                "  Sakura ID: {} (zone: {})",
+                sakura_id.to_string().cyan(),
+                zone
+            );
+
+            // usacloud server boot を呼ぶ (shell out)
+            let status = std::process::Command::new("usacloud")
+                .args([
+                    "server",
+                    "boot",
+                    "-y",
+                    "--zone",
+                    zone,
+                    &sakura_id.to_string(),
+                ])
+                .status()
+                .map_err(|e| anyhow::anyhow!("usacloud 実行失敗: {}", e))?;
+            if !status.success() {
+                println!("{} usacloud server boot 失敗", "✗".red());
+                return Ok(());
+            }
+            println!("{} 電源 ON 命令送信済", "✓".green());
+
+            if *wait {
+                if let Some(host) = host {
+                    println!("  SSH 待機中: {}", host.dimmed());
+                    let start = std::time::Instant::now();
+                    let timeout = std::time::Duration::from_secs(180);
+                    while start.elapsed() < timeout {
+                        let r = std::process::Command::new("nc")
+                            .args(["-zv", "-w", "3", host, "22"])
+                            .output();
+                        if let Ok(out) = r {
+                            if out.status.success() {
+                                println!(
+                                    "{} SSH 通った ({}秒)",
+                                    "✓".green(),
+                                    start.elapsed().as_secs()
+                                );
+                                return Ok(());
+                            }
+                        }
+                        std::thread::sleep(std::time::Duration::from_secs(5));
+                    }
+                    println!("{} SSH 待機 timeout (180s)", "⚠".yellow());
+                }
+            }
+        }
+        ServerCommands::Shutdown { slug } => {
+            println!("{} {}", "Shutdown サーバー:".bold(), slug.cyan());
+            println!();
+
+            let resp = cp_client::request(
+                &client,
+                "server",
+                "get",
+                json!({ "tenant_slug": tenant_slug, "slug": slug }),
+            )
+            .await?;
+            let server = match resp.get("server") {
+                Some(s) => s,
+                None => {
+                    println!("{} {}", "サーバーが見つかりません:".red(), slug);
+                    return Ok(());
+                }
+            };
+            let host = server["dns"]["public_ipv4"]
+                .as_str()
+                .or_else(|| server["ssh_host"].as_str())
+                .ok_or_else(|| anyhow::anyhow!("ssh_host が未設定"))?;
+            let ssh_user = server["ssh_user"].as_str().unwrap_or("root");
+            // root 以外は sudo 必須 (passwordless 必須、要 visudo 設定)
+            let sudo_prefix = if ssh_user == "root" { "" } else { "sudo " };
+            let remote_cmd = format!(
+                "{}shutdown -h +1 'Manual shutdown via fleet cp server shutdown'",
+                sudo_prefix
+            );
+
+            // graceful shutdown via SSH
+            let status = std::process::Command::new("ssh")
+                .args([
+                    "-o",
+                    "BatchMode=yes",
+                    &format!("{ssh_user}@{host}"),
+                    &remote_cmd,
+                ])
+                .status()
+                .map_err(|e| anyhow::anyhow!("ssh 実行失敗: {}", e))?;
+            if status.success() {
+                println!("{} shutdown -h +1 発行 (1m 後に poweroff)", "✓".green());
+            } else {
+                println!(
+                    "{} shutdown 発行失敗 (sudo 設定確認: {} に passwordless shutdown 必要)",
+                    "✗".red(),
+                    ssh_user.dimmed()
+                );
+            }
+        }
     }
 
     client.disconnect().await.ok();

--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -380,9 +380,7 @@ pub async fn handle_server(cmd: &ServerCommands) -> Result<()> {
                 }
             };
             let sakura_id = server["sakura"]["server_id"].as_i64().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "sakura.server_id が記録されていません (record の populate が必要)"
-                )
+                anyhow::anyhow!("sakura.server_id が記録されていません (record の populate が必要)")
             })?;
             let zone = server["sakura"]["zone"].as_str().unwrap_or("tk1a");
             let host = server["dns"]["public_ipv4"]

--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -415,13 +415,15 @@ pub async fn handle_server(cmd: &ServerCommands) -> Result<()> {
                 println!("  SSH 待機中: {}", host.dimmed());
                 let start = std::time::Instant::now();
                 let timeout = std::time::Duration::from_secs(180);
+                let target = format!("{host}:22");
                 while start.elapsed() < timeout {
-                    let r = std::process::Command::new("nc")
-                        .args(["-zv", "-w", "3", host, "22"])
-                        .output();
-                    if let Ok(out) = r
-                        && out.status.success()
-                    {
+                    // Pure-Rust TCP probe (no external nc dependency)
+                    let connect_result = tokio::time::timeout(
+                        std::time::Duration::from_secs(3),
+                        tokio::net::TcpStream::connect(&target),
+                    )
+                    .await;
+                    if let Ok(Ok(_)) = connect_result {
                         println!(
                             "{} SSH 通った ({}秒)",
                             "✓".green(),
@@ -429,7 +431,7 @@ pub async fn handle_server(cmd: &ServerCommands) -> Result<()> {
                         );
                         return Ok(());
                     }
-                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 }
                 println!("{} SSH 待機 timeout (180s)", "⚠".yellow());
             }

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -374,6 +374,20 @@ enum ServerCommands {
         /// サーバーのホスト名（Tailscale ノード名）
         hostname: String,
     },
+    /// サーバーを電源 ON (idle-shutdown 後の wake-up 用)
+    /// CP DB の server.sakura.server_id を読み、usacloud server boot を呼ぶ
+    Boot {
+        /// サーバーのスラッグ
+        slug: String,
+        /// SSH 接続まで wait する (default: true)
+        #[arg(long, default_value_t = true)]
+        wait: bool,
+    },
+    /// サーバーを電源 OFF (graceful shutdown via SSH)
+    Shutdown {
+        /// サーバーのスラッグ
+        slug: String,
+    },
 }
 
 /// コスト管理のサブコマンド

--- a/scripts/idle-shutdown.service
+++ b/scripts/idle-shutdown.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Idle auto-shutdown check
+Documentation=https://github.com/chronista-club/fleetflow/blob/main/docs/design/30-build-tier.md
+# Docker / fleet-agent が落ちている時は idle 検知しても意味がないので、
+# 動作中の場合のみ check する (失敗時は次回 timer fire まで待つ)
+After=docker.service fleet-agent.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/idle-shutdown.sh
+StandardOutput=journal
+StandardError=journal
+# shutdown 発行に必要な権限
+User=root

--- a/scripts/idle-shutdown.sh
+++ b/scripts/idle-shutdown.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Idle auto-shutdown — VM が idle 状態のとき自動で poweroff する
+#
+# Build Tier B1 worker (build-01 等) で常時稼働コストを削減するため、
+# 一定時間 idle なら kernel shutdown を発行する。
+#
+# 使い方 (systemd timer 経由、手動実行不要):
+#   systemctl enable --now idle-shutdown.timer
+#
+# 一時 disable:
+#   touch /run/idle-shutdown.disable
+#
+# 永続 disable:
+#   systemctl disable --now idle-shutdown.timer
+#
+# 環境変数 (override 可能):
+#   IDLE_THRESHOLD_MIN   shutdown までの idle 時間 (default: 15)
+#   MIN_UPTIME_MIN       boot 直後の即 shutdown 回避 (default: 15)
+#   GRACE_SECONDS        shutdown まで wait 時間 (default: 60、journal で確認余地)
+
+set -euo pipefail
+
+IDLE_THRESHOLD_MIN="${IDLE_THRESHOLD_MIN:-15}"
+MIN_UPTIME_MIN="${MIN_UPTIME_MIN:-15}"
+GRACE_SECONDS="${GRACE_SECONDS:-60}"
+DISABLE_FLAG="/run/idle-shutdown.disable"
+
+log() {
+  echo "[idle-shutdown] $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"
+}
+
+# ─────────────────────────────────────────
+# 1. Disable flag check (manual escape hatch)
+# ─────────────────────────────────────────
+if [ -f "${DISABLE_FLAG}" ]; then
+  log "skip: ${DISABLE_FLAG} exists (manually disabled)"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 2. Boot 直後の即 shutdown を回避
+# ─────────────────────────────────────────
+UPTIME_MIN=$(awk '{printf "%d", $1/60}' /proc/uptime)
+if [ "${UPTIME_MIN}" -lt "${MIN_UPTIME_MIN}" ]; then
+  log "skip: uptime ${UPTIME_MIN}m < ${MIN_UPTIME_MIN}m (fresh boot)"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 3. Active な build process がないか
+# ─────────────────────────────────────────
+if pgrep -af 'cargo|rustc' > /dev/null 2>&1; then
+  log "skip: active cargo/rustc process running"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 4. Active SSH session がないか
+# ─────────────────────────────────────────
+SSH_USERS=$(who | wc -l)
+if [ "${SSH_USERS}" -gt 0 ]; then
+  log "skip: ${SSH_USERS} active session(s) (who)"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 5. 直近 15 min 以内の SSH login がなかったか (last 経由)
+# ─────────────────────────────────────────
+# last -F は frozen format (固定幅 column)、最新 1 件
+# "still logged in" あるいは現在 connection なら exit (既に上で who 確認済だが二重防御)
+LAST_LINE=$(last -F -n 5 | grep -v '^$\|^wtmp\|^reboot' | head -1 || true)
+if [ -n "${LAST_LINE}" ]; then
+  # epoch from last login or last logout
+  LAST_TS=$(echo "${LAST_LINE}" | awk '{print $5, $6, $7, $8}')
+  if [ -n "${LAST_TS}" ]; then
+    LAST_EPOCH=$(date -d "${LAST_TS}" +%s 2>/dev/null || echo "0")
+    NOW_EPOCH=$(date +%s)
+    AGE_MIN=$(( (NOW_EPOCH - LAST_EPOCH) / 60 ))
+    if [ "${AGE_MIN}" -lt "${IDLE_THRESHOLD_MIN}" ]; then
+      log "skip: last activity ${AGE_MIN}m ago < ${IDLE_THRESHOLD_MIN}m"
+      exit 0
+    fi
+  fi
+fi
+
+# ─────────────────────────────────────────
+# 6. 全条件満たした → shutdown
+# ─────────────────────────────────────────
+log "idle detected (uptime=${UPTIME_MIN}m, no cargo, no ssh) — shutting down in ${GRACE_SECONDS}s"
+log "  to cancel: shutdown -c"
+
+# +1 (1 分後) shutdown をスケジュール、journal に記録残す
+shutdown -h "+$((GRACE_SECONDS / 60 + 1))" "Idle auto-shutdown ($(date -u +%FT%TZ))" 2>&1 | tee -a /var/log/idle-shutdown.log

--- a/scripts/idle-shutdown.sh
+++ b/scripts/idle-shutdown.sh
@@ -49,7 +49,7 @@ fi
 # ─────────────────────────────────────────
 # 3. Active な build process がないか
 # ─────────────────────────────────────────
-if pgrep -af 'cargo|rustc' > /dev/null 2>&1; then
+if pgrep -f 'cargo|rustc' > /dev/null 2>&1; then
   log "skip: active cargo/rustc process running"
   exit 0
 fi

--- a/scripts/idle-shutdown.timer
+++ b/scripts/idle-shutdown.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Idle auto-shutdown timer (every 5 minutes)
+Documentation=https://github.com/chronista-club/fleetflow/blob/main/docs/design/30-build-tier.md
+
+[Timer]
+# 起動後 5 分待ってから初回実行 (boot 中の処理を避ける)
+OnBootSec=5min
+# その後 5 分毎に実行
+OnUnitActiveSec=5min
+Unit=idle-shutdown.service
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install-idle-shutdown.sh
+++ b/scripts/install-idle-shutdown.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Install idle-shutdown timer on a worker host (self-contained)
+#
+# 使い方:
+#   ssh root@<host> 'bash -s' < scripts/install-idle-shutdown.sh
+#
+# 冪等性: 既存 install を上書き + restart。
+# Disable: touch /run/idle-shutdown.disable (一時)
+#          systemctl disable --now idle-shutdown.timer (永続)
+
+set -euo pipefail
+
+echo "=== idle-shutdown install ==="
+echo "  host: $(hostname)"
+echo "  date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# 1. /usr/local/bin/idle-shutdown.sh
+cat > /usr/local/bin/idle-shutdown.sh <<'SCRIPT_INNER'
+#!/usr/bin/env bash
+# Idle auto-shutdown — VM が idle 状態のとき自動で poweroff する
+#
+# Build Tier B1 worker (build-01 等) で常時稼働コストを削減するため、
+# 一定時間 idle なら kernel shutdown を発行する。
+#
+# 使い方 (systemd timer 経由、手動実行不要):
+#   systemctl enable --now idle-shutdown.timer
+#
+# 一時 disable:
+#   touch /run/idle-shutdown.disable
+#
+# 永続 disable:
+#   systemctl disable --now idle-shutdown.timer
+#
+# 環境変数 (override 可能):
+#   IDLE_THRESHOLD_MIN   shutdown までの idle 時間 (default: 15)
+#   MIN_UPTIME_MIN       boot 直後の即 shutdown 回避 (default: 15)
+#   GRACE_SECONDS        shutdown まで wait 時間 (default: 60、journal で確認余地)
+
+set -euo pipefail
+
+IDLE_THRESHOLD_MIN="${IDLE_THRESHOLD_MIN:-15}"
+MIN_UPTIME_MIN="${MIN_UPTIME_MIN:-15}"
+GRACE_SECONDS="${GRACE_SECONDS:-60}"
+DISABLE_FLAG="/run/idle-shutdown.disable"
+
+log() {
+  echo "[idle-shutdown] $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"
+}
+
+# ─────────────────────────────────────────
+# 1. Disable flag check (manual escape hatch)
+# ─────────────────────────────────────────
+if [ -f "${DISABLE_FLAG}" ]; then
+  log "skip: ${DISABLE_FLAG} exists (manually disabled)"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 2. Boot 直後の即 shutdown を回避
+# ─────────────────────────────────────────
+UPTIME_MIN=$(awk '{printf "%d", $1/60}' /proc/uptime)
+if [ "${UPTIME_MIN}" -lt "${MIN_UPTIME_MIN}" ]; then
+  log "skip: uptime ${UPTIME_MIN}m < ${MIN_UPTIME_MIN}m (fresh boot)"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 3. Active な build process がないか
+# ─────────────────────────────────────────
+if pgrep -af 'cargo|rustc' > /dev/null 2>&1; then
+  log "skip: active cargo/rustc process running"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 4. Active SSH session がないか
+# ─────────────────────────────────────────
+SSH_USERS=$(who | wc -l)
+if [ "${SSH_USERS}" -gt 0 ]; then
+  log "skip: ${SSH_USERS} active session(s) (who)"
+  exit 0
+fi
+
+# ─────────────────────────────────────────
+# 5. 直近 15 min 以内の SSH login がなかったか (last 経由)
+# ─────────────────────────────────────────
+# last -F は frozen format (固定幅 column)、最新 1 件
+# "still logged in" あるいは現在 connection なら exit (既に上で who 確認済だが二重防御)
+LAST_LINE=$(last -F -n 5 | grep -v '^$\|^wtmp\|^reboot' | head -1 || true)
+if [ -n "${LAST_LINE}" ]; then
+  # epoch from last login or last logout
+  LAST_TS=$(echo "${LAST_LINE}" | awk '{print $5, $6, $7, $8}')
+  if [ -n "${LAST_TS}" ]; then
+    LAST_EPOCH=$(date -d "${LAST_TS}" +%s 2>/dev/null || echo "0")
+    NOW_EPOCH=$(date +%s)
+    AGE_MIN=$(( (NOW_EPOCH - LAST_EPOCH) / 60 ))
+    if [ "${AGE_MIN}" -lt "${IDLE_THRESHOLD_MIN}" ]; then
+      log "skip: last activity ${AGE_MIN}m ago < ${IDLE_THRESHOLD_MIN}m"
+      exit 0
+    fi
+  fi
+fi
+
+# ─────────────────────────────────────────
+# 6. 全条件満たした → shutdown
+# ─────────────────────────────────────────
+log "idle detected (uptime=${UPTIME_MIN}m, no cargo, no ssh) — shutting down in ${GRACE_SECONDS}s"
+log "  to cancel: shutdown -c"
+
+# +1 (1 分後) shutdown をスケジュール、journal に記録残す
+shutdown -h "+$((GRACE_SECONDS / 60 + 1))" "Idle auto-shutdown ($(date -u +%FT%TZ))" 2>&1 | tee -a /var/log/idle-shutdown.log
+SCRIPT_INNER
+chmod +x /usr/local/bin/idle-shutdown.sh
+echo "[1/4] /usr/local/bin/idle-shutdown.sh installed"
+
+# 2. /etc/systemd/system/idle-shutdown.service
+cat > /etc/systemd/system/idle-shutdown.service <<'SERVICE_INNER'
+[Unit]
+Description=Idle auto-shutdown check
+Documentation=https://github.com/chronista-club/fleetflow/blob/main/docs/design/30-build-tier.md
+# Docker / fleet-agent が落ちている時は idle 検知しても意味がないので、
+# 動作中の場合のみ check する (失敗時は次回 timer fire まで待つ)
+After=docker.service fleet-agent.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/idle-shutdown.sh
+StandardOutput=journal
+StandardError=journal
+# shutdown 発行に必要な権限
+User=root
+SERVICE_INNER
+echo "[2/4] /etc/systemd/system/idle-shutdown.service installed"
+
+# 3. /etc/systemd/system/idle-shutdown.timer
+cat > /etc/systemd/system/idle-shutdown.timer <<'TIMER_INNER'
+[Unit]
+Description=Idle auto-shutdown timer (every 5 minutes)
+Documentation=https://github.com/chronista-club/fleetflow/blob/main/docs/design/30-build-tier.md
+
+[Timer]
+# 起動後 5 分待ってから初回実行 (boot 中の処理を避ける)
+OnBootSec=5min
+# その後 5 分毎に実行
+OnUnitActiveSec=5min
+Unit=idle-shutdown.service
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMER_INNER
+echo "[3/4] /etc/systemd/system/idle-shutdown.timer installed"
+
+# 4. systemd daemon-reload + enable + start
+systemctl daemon-reload
+systemctl enable --now idle-shutdown.timer
+echo "[4/4] timer enabled & started"
+
+echo ""
+echo "=== status ==="
+systemctl list-timers idle-shutdown.timer --no-pager 2>&1 | head -5
+echo ""
+echo "=== controls ==="
+echo "  一時 disable: touch /run/idle-shutdown.disable"
+echo "  永続 disable: systemctl disable --now idle-shutdown.timer"
+echo "  shutdown cancel: shutdown -c"
+echo "  log: journalctl -u idle-shutdown -n 20"

--- a/scripts/install-idle-shutdown.sh
+++ b/scripts/install-idle-shutdown.sh
@@ -10,6 +10,12 @@
 
 set -euo pipefail
 
+# Root が必須 (systemd unit / /usr/local/bin への書き込み)
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+  echo "error: must run as root (sudo or root login)" >&2
+  exit 1
+fi
+
 echo "=== idle-shutdown install ==="
 echo "  host: $(hostname)"
 echo "  date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -67,7 +73,7 @@ fi
 # ─────────────────────────────────────────
 # 3. Active な build process がないか
 # ─────────────────────────────────────────
-if pgrep -af 'cargo|rustc' > /dev/null 2>&1; then
+if pgrep -f 'cargo|rustc' > /dev/null 2>&1; then
   log "skip: active cargo/rustc process running"
   exit 0
 fi


### PR DESCRIPTION
## Summary

Build Tier B1 worker (build-01 等) を **15 分 idle で自動 shutdown** する systemd timer + script。常時稼働コスト ¥3,300/月 を「使用時のみ」に削減 (~80% 圧縮見込み)。

design memo の `docs/design/30-build-tier.md` 2.4 で idle auto-shutdown を約束していた具体実装。

## ファイル構成

* `scripts/idle-shutdown.sh` — idle 検知 + shutdown 発行 (5 段階 AND check)
* `scripts/idle-shutdown.service` — oneshot wrapper
* `scripts/idle-shutdown.timer` — 5 分毎 fire
* `scripts/install-idle-shutdown.sh` — 3 ファイルを **self-contained 1 コマンド**で install

## Idle 検知条件 (全部満たすと shutdown)

| # | check | 目的 |
|---|---|---|
| 1 | `/run/idle-shutdown.disable` flag 不在 | manual escape hatch |
| 2 | uptime > `MIN_UPTIME_MIN` (default 15 min) | boot 直後の事故防止 |
| 3 | cargo / rustc process なし | active build を保護 |
| 4 | `who` で active session なし | SSH 中のユーザー保護 |
| 5 | 直近 `IDLE_THRESHOLD_MIN` (default 15) min 以内の login なし | 直近活動の余韻 |

満たすと `shutdown -h +2 "Idle auto-shutdown"` を発行 (`shutdown -c` で cancel 可能)。

## 既知の限界 (Phase 2.5 で対応)

* **CP-side auto-boot 未実装**: 新 build job 到来時の自動 wake-up は手動 `usacloud server boot <id>` 必要
* 将来: `fleet workers boot <slug>` CLI + CP build job dispatcher で auto wake-up

## 検証

build-01 で実 install 完了:

```
ssh build-01 'bash -s' < scripts/install-idle-shutdown.sh
[1/4] /usr/local/bin/idle-shutdown.sh installed
[2/4] /etc/systemd/system/idle-shutdown.service installed
[3/4] /etc/systemd/system/idle-shutdown.timer installed
[4/4] timer enabled & started
```

初回 fire で **正しく idle 検知 → shutdown -h +2 発行** を確認:
- uptime 17h40m (> 15 min ✓)
- cargo process なし ✓
- who 0 user ✓
- 結果: `shutdown -h "+2"` 発行 → `shutdown -c` で cancel + `/run/idle-shutdown.disable` で testing 中の自動 shutdown を停止

## Test plan

- [x] `bash -n` syntax check
- [x] build-01 で install + 初回 fire 動作確認
- [x] disable flag による override 動作確認
- [x] cancel via `shutdown -c` 動作確認
- [ ] CI 全 green
- [ ] Phase 2.5: CP-side auto-boot 実装 (別 PR)

🤖 Generated with Claude Code
