### PR TITLE
fix(idle-shutdown): tighten defaults to 10min for build-tier cost

### DIFF
--- a/scripts/idle-shutdown.sh
+++ b/scripts/idle-shutdown.sh
@@ -14,14 +14,14 @@
 #   systemctl disable --now idle-shutdown.timer
 #
 # 環境変数 (override 可能):
-#   IDLE_THRESHOLD_MIN   shutdown までの idle 時間 (default: 15)
-#   MIN_UPTIME_MIN       boot 直後の即 shutdown 回避 (default: 15)
+#   IDLE_THRESHOLD_MIN   shutdown までの idle 時間 (default: 10)
+#   MIN_UPTIME_MIN       boot 直後の即 shutdown 回避 (default: 10)
 #   GRACE_MIN            shutdown 発行から実 poweroff までの猶予 (default: 2 min、journal で確認 + cancel 余地)
 
 set -euo pipefail
 
-IDLE_THRESHOLD_MIN="${IDLE_THRESHOLD_MIN:-15}"
-MIN_UPTIME_MIN="${MIN_UPTIME_MIN:-15}"
+IDLE_THRESHOLD_MIN="${IDLE_THRESHOLD_MIN:-10}"
+MIN_UPTIME_MIN="${MIN_UPTIME_MIN:-10}"
 GRACE_MIN="${GRACE_MIN:-2}"
 DISABLE_FLAG="/run/idle-shutdown.disable"
 

--- a/scripts/install-idle-shutdown.sh
+++ b/scripts/install-idle-shutdown.sh
@@ -43,14 +43,14 @@ cat > /usr/local/bin/idle-shutdown.sh <<'SCRIPT_INNER'
 #   systemctl disable --now idle-shutdown.timer
 #
 # 環境変数 (override 可能):
-#   IDLE_THRESHOLD_MIN   shutdown までの idle 時間 (default: 15)
-#   MIN_UPTIME_MIN       boot 直後の即 shutdown 回避 (default: 15)
+#   IDLE_THRESHOLD_MIN   shutdown までの idle 時間 (default: 10)
+#   MIN_UPTIME_MIN       boot 直後の即 shutdown 回避 (default: 10)
 #   GRACE_MIN            shutdown 発行から実 poweroff までの猶予 (default: 2 min、journal で確認 + cancel 余地)
 
 set -euo pipefail
 
-IDLE_THRESHOLD_MIN="${IDLE_THRESHOLD_MIN:-15}"
-MIN_UPTIME_MIN="${MIN_UPTIME_MIN:-15}"
+IDLE_THRESHOLD_MIN="${IDLE_THRESHOLD_MIN:-10}"
+MIN_UPTIME_MIN="${MIN_UPTIME_MIN:-10}"
 GRACE_MIN="${GRACE_MIN:-2}"
 DISABLE_FLAG="/run/idle-shutdown.disable"
 


### PR DESCRIPTION
## Summary

build-tier worker (build-01, build-02 予定) のインタラクティブ idle 検知を **15min → 10min** に短縮。submit → build → 確認 → 別作業 のバースト型ワークフローに合わせた cost 削減。

## 変更点

| 項目 | 旧 | 新 |
|------|----|----|
| IDLE_THRESHOLD_MIN | 15 | **10** |
| MIN_UPTIME_MIN | 15 | **10** |
| GRACE_MIN | 2 | 2 (維持) |
| timer 周期 | 5min/5min | 維持 |

実効: SSH 切断から **最短 12min / 最長 17min** で poweroff (timer 5min ばらつき + grace 2min 含む)。

## Risk / Mitigation

- 誤判定 shutdown 時の再 boot コスト = ~10-30秒 (Phase 2.5 `fleet cp server boot --wait` 既存)
- 重い build (cargo / docker) 中は `pgrep -f 'cargo|rustc'` でガードされるため shutdown されない
- SSH session 中も `who` で守られる
- 一時 disable は `touch /run/idle-shutdown.disable` で従来通り

## Test plan

- [ ] generated install-idle-shutdown.sh の DEFAULT 値が 10/10 を読める
- [ ] build-01 に再 deploy → SSH 切断 → 12-17min 範囲内で poweroff 確認
- [ ] cargo build 中は守られる (build > 15min なら自然に守られる)

🤖 Generated with [Claude Code](https://claude.com/claude-code)