### PR TITLE
refactor(cloud-aws): gate behind aws-cloud feature (default off)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ fleetflow-build = { version = "0.14.2", path = "crates/fleetflow-build" }
 fleetflow-cloud = { version = "0.14.2", path = "crates/fleetflow-cloud" }
 fleetflow-cloud-sakura = { version = "0.14.2", path = "crates/fleetflow-cloud-sakura" }
 fleetflow-cloud-cloudflare = { version = "0.14.2", path = "crates/fleetflow-cloud-cloudflare" }
+# fleetflow-cloud-aws は default features off。controlplane の `aws-cloud`
+# feature 有効化時のみ link される (aws-sdk-ec2 chain は rustc 1 instance
+# あたり 6-7GB 食うため、小さい build worker での OOM を避ける)。
+# `cargo build -p fleetflowd -p fleet-agent` だと完全に skip される。
+# 利用時: `cargo build -p fleetflowd --features fleetflow-controlplane/aws-cloud`
 fleetflow-cloud-aws = { version = "0.14.2", path = "crates/fleetflow-cloud-aws" }
 fleetflow-mcp = { version = "0.14.2", path = "crates/fleetflow-mcp" }
 fleetflow-registry = { version = "0.14.2", path = "crates/fleetflow-registry" }

--- a/crates/fleetflow-controlplane/Cargo.toml
+++ b/crates/fleetflow-controlplane/Cargo.toml
@@ -14,7 +14,8 @@ fleetflow-container.workspace = true
 fleetflow-cloud.workspace = true
 fleetflow-cloud-sakura.workspace = true
 fleetflow-cloud-cloudflare.workspace = true
-fleetflow-cloud-aws.workspace = true
+# AWS provider は feature `aws-cloud` で有効化 (default off)
+fleetflow-cloud-aws = { workspace = true, optional = true }
 
 # Communication
 unison.workspace = true
@@ -53,6 +54,9 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 [features]
 test-utils = []
+# AWS EC2 Provider を有効化。aws-sdk-ec2 chain (~6-7GB rustc per instance) を
+# 引き込むので default off。利用時のみ `--features aws-cloud` で enable。
+aws-cloud = ["dep:fleetflow-cloud-aws"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/fleetflow-controlplane/src/server_provider.rs
+++ b/crates/fleetflow-controlplane/src/server_provider.rs
@@ -12,7 +12,8 @@ pub enum ServerProviderKind {
     /// さくらクラウド（usacloud CLI 経由）
     Sakura(fleetflow_cloud_sakura::SakuraCloudProvider),
 
-    /// AWS（EC2 API 経由）
+    /// AWS（EC2 API 経由）— feature `aws-cloud` で有効化 (default off)
+    #[cfg(feature = "aws-cloud")]
     Aws(fleetflow_cloud_aws::AwsServerProvider),
 
     /// テスト用モック
@@ -24,6 +25,7 @@ impl ServerProviderKind {
     pub fn provider_name(&self) -> &str {
         match self {
             Self::Sakura(p) => fleetflow_cloud::server_provider::ServerProvider::provider_name(p),
+            #[cfg(feature = "aws-cloud")]
             Self::Aws(p) => fleetflow_cloud::server_provider::ServerProvider::provider_name(p),
             #[cfg(feature = "test-utils")]
             Self::Mock(m) => &m.name,
@@ -35,6 +37,7 @@ impl ServerProviderKind {
             Self::Sakura(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::list_servers(p).await
             }
+            #[cfg(feature = "aws-cloud")]
             Self::Aws(p) => fleetflow_cloud::server_provider::ServerProvider::list_servers(p).await,
             #[cfg(feature = "test-utils")]
             Self::Mock(_) => Ok(vec![]),
@@ -46,6 +49,7 @@ impl ServerProviderKind {
             Self::Sakura(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::get_server(p, server_id).await
             }
+            #[cfg(feature = "aws-cloud")]
             Self::Aws(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::get_server(p, server_id).await
             }
@@ -62,6 +66,7 @@ impl ServerProviderKind {
             Self::Sakura(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::create_server(p, request).await
             }
+            #[cfg(feature = "aws-cloud")]
             Self::Aws(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::create_server(p, request).await
             }
@@ -82,6 +87,7 @@ impl ServerProviderKind {
                 )
                 .await
             }
+            #[cfg(feature = "aws-cloud")]
             Self::Aws(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::delete_server(
                     p, server_id, with_disks,
@@ -98,6 +104,7 @@ impl ServerProviderKind {
             Self::Sakura(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::power_on(p, server_id).await
             }
+            #[cfg(feature = "aws-cloud")]
             Self::Aws(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::power_on(p, server_id).await
             }
@@ -111,6 +118,7 @@ impl ServerProviderKind {
             Self::Sakura(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::power_off(p, server_id).await
             }
+            #[cfg(feature = "aws-cloud")]
             Self::Aws(p) => {
                 fleetflow_cloud::server_provider::ServerProvider::power_off(p, server_id).await
             }


### PR DESCRIPTION
## Summary

`fleetflow-cloud-aws` を default build から外す。aws-sdk-ec2 chain (rustc 1 instance あたり ~6-7GB) を引き込まなくなるので、小さい build worker での OOM 回避と、build 時間短縮が同時に得られる。

## 変更

- `crates/fleetflow-controlplane/Cargo.toml`: `fleetflow-cloud-aws` を `optional = true` に + `[features] aws-cloud = [\"dep:fleetflow-cloud-aws\"]`
- `crates/fleetflow-controlplane/src/server_provider.rs`: `ServerProviderKind::Aws` variant + 対応する match arm 全部を `#[cfg(feature = \"aws-cloud\")]` で gate
- `Cargo.toml`: workspace.dependencies の comment 追加（再有効化手順）

## なぜ削除しないか

- `Aws` variant は instantiate 箇所ゼロ (dead code) だが、再利用時のコスト下げるため code は残置
- crate dir 自体も残す (`crates/fleetflow-cloud-aws/`)
- 「使う時にまた考えよう」(user feedback) を尊重

## 動作

| build target | aws compiled? |
|--------------|---------------|
| `cargo build -p fleetflowd -p fleet-agent` (dogfood) | ❌ skip ✓ |
| `cargo build --workspace` | ⚠️ build (member だから) |
| `cargo build -p fleetflowd --features fleetflow-controlplane/aws-cloud` | ✓ build (有効化時) |

dogfood 経路で完全に skip されるのが目標。`--workspace` はそのまま全 build (CI / release script は `-p fleetflow` 指定なので影響なし)。

## 検証

\`\`\`
$ cargo check -p fleetflowd -p fleet-agent --message-format=short 2>&1 | grep -i aws
(no output)
\`\`\`

## Test plan

- [ ] CI default features build で fleetflow-cloud-aws / aws-sdk-* が compile されない
- [ ] feature opt-in build (\`--features aws-cloud\`) で aws crate が compile される
- [ ] release.yml の \`-p fleetflow\` パスは無影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)