### PR TITLE
docs(scripts): annotate --with-disks risk in spawn-build-worker cleanup hints

### DIFF
--- a/scripts/spawn-build-worker.sh
+++ b/scripts/spawn-build-worker.sh
@@ -34,6 +34,10 @@
 #   8. サマリ表示 (公開IP / Tailscale IP / 月コスト目安 / 削除コマンド)
 #
 # 失敗時の手動 cleanup:
+#   注: `--with-disks` は disk も同時削除するため復旧不可。 ephemeral build worker
+#   なら問題ないが、 disk 中身の確認が必要なら `--with-disks` を外して server だけ
+#   削除し、 disk は `usacloud disk list --zone <zone>` で確認してから別途処分。
+#
 #   usacloud server delete -y --with-disks --zone <zone> <SERVER_ID>
 #   op item delete <password-item-id> --vault FleetFlowVault
 #   ~/.ssh/config から Host <hostname> ブロック削除
@@ -509,7 +513,9 @@ cat <<SUMMARY
   ssh:            ssh ${NAME}      # 公開 IP 経由
 $([ -n "${TS_IP}" ] && echo "                  ssh ${NAME}-ts   # Tailscale 経由")
 
-  cleanup:        usacloud server delete -y --with-disks --zone ${ZONE} ${SERVER_ID}
+  cleanup:        # 注: --with-disks は disk も同時削除 (復旧不可)。 中身確認が必要
+                  #     なら --with-disks を外して、 disk list で確認後別途削除
+                  usacloud server delete -y --with-disks --zone ${ZONE} ${SERVER_ID}
                   op item delete ${PW_ITEM_ID} --vault ${OP_VAULT}
 $([ ${USE_FLEET_AGENT} -eq 1 ] && echo "                  fleet cp server delete --slug ${FLEET_SLUG}   # CP-side")
 SUMMARY


### PR DESCRIPTION
## Summary

PR #159 follow-up。 `spawn-build-worker.sh` の cleanup hint で `--with-disks` を生で出していたが、 disk 削除は復旧不可であることを明示する前置文を 2 箇所 (doc top + Phase 8 summary) に追加。

機能変更なし、 docs only。

## 背景

2026-04-30、 user から「ディスクは消す時は必ず私に確認とったあと行ってください」 ルールが明示された。 spawn-build-worker.sh の cleanup hint は **コピペで実行する手動コマンドの提案** だが、 \`--with-disks\` のリスクが目立たないと "気付いたら disk 消えてた" 事故が起こり得る。

## 変更点

doc top と Phase 8 summary の cleanup section に:
> 注: \`--with-disks\` は disk も同時削除 (復旧不可)。 中身確認が必要なら \`--with-disks\` を外して、 disk list で確認後別途削除

を追加。 ephemeral build worker (今回のユースケース) では問題ないが、 共有 worker や production 用途では中身確認 step を user の意識に上げる狙い。

## Test plan

- [x] \`bash -n\` syntax check
- [ ] CI 全 green
- [ ] Reviewer: 文言レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)