### PR TITLE
fix(cloud-sakura): propagate parse / serialize errors for note_vars

### DIFF
--- a/crates/fleetflow-cloud-sakura/src/usacloud.rs
+++ b/crates/fleetflow-cloud-sakura/src/usacloud.rs
@@ -181,16 +181,26 @@ impl Usacloud {
         // Build note vars JSON array if provided
         // Format: [{"ID": 123456789012, "Variables": {"key": "value"}}]
         let note_vars_json: Option<String> = if let Some(ref note_vars) = config.note_vars {
+            // 旧実装は note_id.parse::<u64>() 失敗で silent に 0、 to_string 失敗で
+            // 空文字に fallback していた → Sakura API レベルで謎エラーになる anti-pattern。
+            // local validation で早期に明示エラーを返す。
             let notes_array: Vec<serde_json::Value> = note_vars
                 .iter()
                 .map(|(note_id, vars)| {
-                    serde_json::json!({
-                        "ID": note_id.parse::<u64>().unwrap_or(0),
-                        "Variables": vars
-                    })
+                    let id: u64 = note_id.parse().map_err(|e| {
+                        SakuraError::CreationFailed(format!(
+                            "invalid note_id '{}' (expected u64 startup script ID): {}",
+                            note_id, e
+                        ))
+                    })?;
+                    Ok(serde_json::json!({
+                        "ID": id,
+                        "Variables": vars,
+                    }))
                 })
-                .collect();
-            Some(serde_json::to_string(&notes_array).unwrap_or_default())
+                .collect::<Result<Vec<_>>>()?;
+            // serde_json::Error は SakuraError::JsonError に From 実装あり (`?` で OK)
+            Some(serde_json::to_string(&notes_array)?)
         } else {
             None
         };

--- a/scripts/spawn-build-worker.sh
+++ b/scripts/spawn-build-worker.sh
@@ -34,6 +34,10 @@
 #   8. サマリ表示 (公開IP / Tailscale IP / 月コスト目安 / 削除コマンド)
 #
 # 失敗時の手動 cleanup:
+#   注: `--with-disks` は disk も同時削除するため復旧不可。 ephemeral build worker
+#   なら問題ないが、 disk 中身の確認が必要なら `--with-disks` を外して server だけ
+#   削除し、 disk は `usacloud disk list --zone <zone>` で確認してから別途処分。
+#
 #   usacloud server delete -y --with-disks --zone <zone> <SERVER_ID>
 #   op item delete <password-item-id> --vault FleetFlowVault
 #   ~/.ssh/config から Host <hostname> ブロック削除
@@ -509,7 +513,9 @@ cat <<SUMMARY
   ssh:            ssh ${NAME}      # 公開 IP 経由
 $([ -n "${TS_IP}" ] && echo "                  ssh ${NAME}-ts   # Tailscale 経由")
 
-  cleanup:        usacloud server delete -y --with-disks --zone ${ZONE} ${SERVER_ID}
+  cleanup:        # 注: --with-disks は disk も同時削除 (復旧不可)。 中身確認が必要
+                  #     なら --with-disks を外して、 disk list で確認後別途削除
+                  usacloud server delete -y --with-disks --zone ${ZONE} ${SERVER_ID}
                   op item delete ${PW_ITEM_ID} --vault ${OP_VAULT}
 $([ ${USE_FLEET_AGENT} -eq 1 ] && echo "                  fleet cp server delete --slug ${FLEET_SLUG}   # CP-side")
 SUMMARY


### PR DESCRIPTION
## Summary

`Usacloud::create_server` 内で note_vars (Sakura startup script ID + variables map) を JSON 化する際、 silent fallback 2 箇所を **明示エラーに変更**。

## 修正対象

`crates/fleetflow-cloud-sakura/src/usacloud.rs:181-196`

| 旧 | 問題 |
|----|------|
| \`note_id.parse::<u64>().unwrap_or(0)\` | parse 失敗で ID=0 が送られて Sakura 側で「note ID 0 なし」 の謎エラー (user input validation を local で済ませず remote に丸投げ) |
| \`serde_json::to_string(&notes_array).unwrap_or_default()\` | serialize 失敗で空文字 → \`--disk-edit-notes ""\` が渡って別の謎エラー |

## 修正後

両方とも \`?\` で local validation エラーを即時 \`Result\` に流す:

\`\`\`rust
let id: u64 = note_id.parse().map_err(|e| {
    SakuraError::CreationFailed(format!(
        "invalid note_id '{}' (expected u64 startup script ID): {}",
        note_id, e
    ))
})?;
\`\`\`

\`serde_json::to_string\` は \`SakuraError::JsonError\` に \`From<serde_json::Error>\` 実装が既にあるため \`?\` で透過伝播。

## Validation

- [x] \`cargo check -p fleetflow-cloud-sakura\` → 10s green
- [x] \`cargo check -p fleetflowd -p fleet-agent --all-targets\` → 3m50s green (downstream 影響なし)

## 関連

- 元 task: #50 (Minor cleanup PR — \`unwrap_or\` silent default 修正)
- 別の \`unwrap_or_default()\` hits は intentional な optional-config-field 既定値 (provider.rs:319/325/541/551/587) で意図通りなので変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)