### PR TITLE
chore: gitignore .gitnexus/ (code-indexing tool cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ data/
 # Vantage development database
 .vantage/
 
+# Code-indexing tool cache (lbug binary + meta.json、 大きい blob で repo 汚染回避)
+.gitnexus/
+
 # Skills - ホワイトリスト形式
 .claude/skills/*
 !.claude/skills/bollard/


### PR DESCRIPTION
## Summary
`.gitnexus/` (code-indexing tooling cache、 `lbug` binary 約 58MB + `meta.json`) を gitignore に追加。 repo history への大きい blob の混入を永続的に防止。

## Why
- 58MB binary が repo に入ると `git clone` / `git fetch` のコストが上昇
- tooling cache は再生成可能、 commit 不要

## Test plan
- [ ] CI 全 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
