### PR TITLE
fix(controlplane): sprint-1 residuals — submitted_at bind + adopt doc

### DIFF
--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -1316,6 +1316,7 @@ impl Database {
                     source: { git_url: $git_url, git_ref: $git_ref, dockerfile: $dockerfile }, \
                     target: { image: $image, registry_secret: $registry_secret }, \
                     state: $state, server: $server, logs_url: $logs_url, \
+                    submitted_at: $submitted_at, \
                     started_at: $started_at, finished_at: $finished_at, \
                     duration_seconds: $duration_seconds \
                 }",
@@ -1331,6 +1332,9 @@ impl Database {
             .bind(("state", job.state.clone()))
             .bind(("server", job.server.clone()))
             .bind(("logs_url", job.logs_url.clone()))
+            // sprint-1 follow-up: schema には DEFAULT time::now() があるが Rust 側
+            // (DateTime<Utc>) と DB 側で値が一致しないリスク回避のため明示 bind。
+            .bind(("submitted_at", job.submitted_at))
             .bind(("started_at", job.started_at))
             .bind(("finished_at", job.finished_at))
             .bind(("duration_seconds", job.duration_seconds))

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -1689,7 +1689,7 @@ async fn api_volume_adopt(State(state): State<Arc<WebState>>, req: Request) -> i
 // 詳細設計: fleetstage repo Issue FSC-16
 // ============================================================================
 
-/// POST /api/v1/stages/adopt — 既存 stage を非破壊で CP records に登録
+/// POST /api/v1/stages/_adopt — 既存 stage を非破壊で CP records に登録
 ///
 /// リクエスト body:
 /// ```json


### PR DESCRIPTION
## Summary

PR #163 (sprint-1) の moody-blues review で拾った 2 件の minor follow-up を 1 PR にまとめ。

| 内容 | file | size |
|------|------|------|
| (a) \`create_build_job\` SQL に \`submitted_at: \$submitted_at\` 明示 bind 追加 | \`crates/fleetflow-controlplane/src/db.rs:1313\` | XS |
| (b) \`api_stage_adopt\` の rustdoc コメント \`/api/v1/stages/adopt\` → \`_adopt\` 追従 | \`crates/fleetflowd/src/web.rs:1692\` | XS |

## Why
- (a): schema \`DEFAULT time::now()\` で偶然動作していたが Rust caller (\`DateTime<Utc>\`) の値と DB 格納値が一致しないリスクを除去
- (b): PR #163 で route 自体は \`_adopt\` に rename 済、 doc comment が古いままだと caller 混乱

## Test plan
- [x] \`cargo check -p fleetflow-controlplane -p fleetflowd --all-targets\` 16s green
- [x] \`cargo clippy ... -- -D warnings\` 17s green
- [ ] CI 全 green
- [ ] Reviewer: 文言レビュー

## 関連
- 元 task: #50 (Minor cleanup PR) の継続、 sprint-1 (#163) review feedback の (1) + (2) を解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)