### PR TITLE
feat(controlplane): sprint-2 — soft-delete migration (D#4)

### DIFF
--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -178,7 +178,9 @@ impl Database {
     pub async fn resolve_tenant_by_sub(&self, auth0_sub: &str) -> Result<Option<TenantUser>> {
         let mut result = self
             .db
-            .query("SELECT * FROM tenant_user WHERE auth0_sub = $sub AND deleted_at IS NONE LIMIT 1")
+            .query(
+                "SELECT * FROM tenant_user WHERE auth0_sub = $sub AND deleted_at IS NONE LIMIT 1",
+            )
             .bind(("sub", auth0_sub.to_string()))
             .await
             .context("テナントユーザー解決失敗")?;

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -178,7 +178,7 @@ impl Database {
     pub async fn resolve_tenant_by_sub(&self, auth0_sub: &str) -> Result<Option<TenantUser>> {
         let mut result = self
             .db
-            .query("SELECT * FROM tenant_user WHERE auth0_sub = $sub LIMIT 1")
+            .query("SELECT * FROM tenant_user WHERE auth0_sub = $sub AND deleted_at IS NONE LIMIT 1")
             .bind(("sub", auth0_sub.to_string()))
             .await
             .context("テナントユーザー解決失敗")?;
@@ -194,7 +194,7 @@ impl Database {
     ) -> Result<Option<TenantUser>> {
         let mut result = self
             .db
-            .query("SELECT * FROM tenant_user WHERE auth0_sub = $sub AND tenant.slug = $tenant_slug LIMIT 1")
+            .query("SELECT * FROM tenant_user WHERE auth0_sub = $sub AND tenant.slug = $tenant_slug AND deleted_at IS NONE LIMIT 1")
             .bind(("sub", auth0_sub.to_string()))
             .bind(("tenant_slug", tenant_slug.to_string()))
             .await
@@ -221,7 +221,7 @@ impl Database {
     pub async fn list_tenant_users(&self, tenant_slug: &str) -> Result<Vec<TenantUser>> {
         let mut result = self
             .db
-            .query("SELECT * FROM tenant_user WHERE tenant.slug = $tenant_slug ORDER BY role, auth0_sub")
+            .query("SELECT * FROM tenant_user WHERE tenant.slug = $tenant_slug AND deleted_at IS NONE ORDER BY role, auth0_sub")
             .bind(("tenant_slug", tenant_slug.to_string()))
             .await
             .context("テナントユーザー一覧取得失敗")?;
@@ -250,9 +250,10 @@ impl Database {
 
     /// テナントユーザーを削除（テナント境界チェック付き）
     pub async fn delete_tenant_user(&self, auth0_sub: &str, tenant_slug: &str) -> Result<bool> {
+        // D#4 soft-delete: hard DELETE → UPDATE deleted_at で復旧可能 + feedback_no_data_deletion.md 整合
         let mut result = self
             .db
-            .query("DELETE FROM tenant_user WHERE auth0_sub = $sub AND tenant.slug = $tenant_slug RETURN BEFORE")
+            .query("UPDATE tenant_user SET deleted_at = time::now() WHERE auth0_sub = $sub AND tenant.slug = $tenant_slug AND deleted_at IS NONE RETURN BEFORE")
             .bind(("sub", auth0_sub.to_string()))
             .bind(("tenant_slug", tenant_slug.to_string()))
             .await
@@ -305,7 +306,7 @@ impl Database {
         let mut result = self
             .db
             .query(
-                "SELECT * FROM project WHERE slug = $project_slug AND tenant.slug = $tenant_slug LIMIT 1",
+                "SELECT * FROM project WHERE slug = $project_slug AND tenant.slug = $tenant_slug AND deleted_at IS NONE LIMIT 1",
             )
             .bind(("tenant_slug", tenant_slug.to_string()))
             .bind(("project_slug", project_slug.to_string()))
@@ -318,7 +319,7 @@ impl Database {
     pub async fn list_projects_by_tenant(&self, tenant_slug: &str) -> Result<Vec<Project>> {
         let mut result = self
             .db
-            .query("SELECT * FROM project WHERE tenant.slug = $tenant_slug ORDER BY slug")
+            .query("SELECT * FROM project WHERE tenant.slug = $tenant_slug AND deleted_at IS NONE ORDER BY slug")
             .bind(("tenant_slug", tenant_slug.to_string()))
             .await
             .context("プロジェクト一覧取得失敗")?;
@@ -327,8 +328,9 @@ impl Database {
     }
 
     pub async fn delete_project(&self, tenant_slug: &str, project_slug: &str) -> Result<bool> {
+        // D#4 soft-delete: hard DELETE → UPDATE deleted_at で復旧可能 + feedback_no_data_deletion.md 整合
         self.db
-            .query("DELETE FROM project WHERE slug = $project_slug AND tenant.slug = $tenant_slug")
+            .query("UPDATE project SET deleted_at = time::now() WHERE slug = $project_slug AND tenant.slug = $tenant_slug AND deleted_at IS NONE")
             .bind(("tenant_slug", tenant_slug.to_string()))
             .bind(("project_slug", project_slug.to_string()))
             .await
@@ -439,7 +441,7 @@ impl Database {
     ) -> Result<Option<Project>> {
         let mut result = self
             .db
-            .query("SELECT * FROM project WHERE tenant = $tenant AND slug = $slug LIMIT 1")
+            .query("SELECT * FROM project WHERE tenant = $tenant AND slug = $slug AND deleted_at IS NONE LIMIT 1")
             .bind(("tenant", tenant_id.clone()))
             .bind(("slug", project_slug.to_string()))
             .await
@@ -497,6 +499,7 @@ impl Database {
                     repository_url: None,
                     created_at: None,
                     updated_at: None,
+                    deleted_at: None,
                 })
                 .await?
             }
@@ -735,7 +738,7 @@ impl Database {
     pub async fn list_servers_by_tenant(&self, tenant_slug: &str) -> Result<Vec<Server>> {
         let mut result = self
             .db
-            .query("SELECT * FROM server WHERE tenant.slug = $tenant_slug ORDER BY slug")
+            .query("SELECT * FROM server WHERE tenant.slug = $tenant_slug AND deleted_at IS NONE ORDER BY slug")
             .bind(("tenant_slug", tenant_slug.to_string()))
             .await
             .context("サーバー一覧取得失敗")?;
@@ -793,7 +796,7 @@ impl Database {
     pub async fn list_all_servers(&self) -> Result<Vec<Server>> {
         let mut result = self
             .db
-            .query("SELECT * FROM server ORDER BY slug")
+            .query("SELECT * FROM server WHERE deleted_at IS NONE ORDER BY slug")
             .await
             .context("全サーバー一覧取得失敗")?;
         let servers: Vec<Server> = result.take(0)?;
@@ -804,7 +807,7 @@ impl Database {
     pub async fn get_server_by_slug(&self, slug: &str) -> Result<Option<Server>> {
         let mut result = self
             .db
-            .query("SELECT * FROM server WHERE slug = $slug LIMIT 1")
+            .query("SELECT * FROM server WHERE slug = $slug AND deleted_at IS NONE LIMIT 1")
             .bind(("slug", slug.to_string()))
             .await
             .context("サーバー取得失敗")?;
@@ -814,8 +817,9 @@ impl Database {
 
     /// サーバーを DB から削除
     pub async fn delete_server(&self, slug: &str) -> Result<()> {
+        // D#4 soft-delete: hard DELETE → UPDATE deleted_at で復旧可能 + feedback_no_data_deletion.md 整合
         self.db
-            .query("DELETE FROM server WHERE slug = $slug")
+            .query("UPDATE server SET deleted_at = time::now() WHERE slug = $slug AND deleted_at IS NONE")
             .bind(("slug", slug.to_string()))
             .await
             .context("サーバー削除失敗")?;
@@ -946,7 +950,7 @@ impl Database {
     pub async fn list_dns_records_by_tenant(&self, tenant_slug: &str) -> Result<Vec<DnsRecord>> {
         let mut result = self
             .db
-            .query("SELECT * FROM dns_record WHERE tenant.slug = $tenant_slug ORDER BY name")
+            .query("SELECT * FROM dns_record WHERE tenant.slug = $tenant_slug AND deleted_at IS NONE ORDER BY name")
             .bind(("tenant_slug", tenant_slug.to_string()))
             .await
             .context("DNSレコード一覧取得失敗")?;
@@ -955,9 +959,10 @@ impl Database {
     }
 
     pub async fn delete_dns_record(&self, record_name: &str) -> Result<bool> {
+        // D#4 soft-delete: hard DELETE → UPDATE deleted_at で復旧可能 + feedback_no_data_deletion.md 整合
         let mut result = self
             .db
-            .query("DELETE FROM dns_record WHERE name = $name RETURN BEFORE")
+            .query("UPDATE dns_record SET deleted_at = time::now() WHERE name = $name AND deleted_at IS NONE RETURN BEFORE")
             .bind(("name", record_name.to_string()))
             .await
             .context("DNSレコード削除失敗")?;
@@ -1426,6 +1431,8 @@ DEFINE FIELD IF NOT EXISTS description ON project TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS repository_url ON project TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS created_at ON project TYPE option<datetime> DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS updated_at ON project TYPE option<datetime> DEFAULT time::now();
+-- D#4 soft-delete: tombstone (None = active row、UPDATE で time::now() を入れる)
+DEFINE FIELD IF NOT EXISTS deleted_at ON project TYPE option<datetime>;
 DEFINE INDEX IF NOT EXISTS idx_project_tenant_slug ON project FIELDS tenant, slug UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS stage SCHEMAFULL;
@@ -1531,6 +1538,8 @@ DEFINE FIELD IF NOT EXISTS lifecycle.replaced_from ON server TYPE option<record<
 
 DEFINE FIELD IF NOT EXISTS created_at ON server TYPE option<datetime> DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS updated_at ON server TYPE option<datetime> DEFAULT time::now();
+-- D#4 soft-delete: tombstone (None = active row)
+DEFINE FIELD IF NOT EXISTS deleted_at ON server TYPE option<datetime>;
 DEFINE INDEX IF NOT EXISTS idx_server_tenant_slug ON server FIELDS tenant, slug UNIQUE;
 
 -- FSC-26 Phase B-2: Worker Pool (複数 Server を label で束ねた論理グループ)
@@ -1580,6 +1589,8 @@ DEFINE FIELD IF NOT EXISTS cf_record_id ON dns_record TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS proxied ON dns_record TYPE bool DEFAULT false;
 DEFINE FIELD IF NOT EXISTS created_at ON dns_record TYPE option<datetime> DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS updated_at ON dns_record TYPE option<datetime> DEFAULT time::now();
+-- D#4 soft-delete: tombstone (None = active row)
+DEFINE FIELD IF NOT EXISTS deleted_at ON dns_record TYPE option<datetime>;
 DEFINE INDEX IF NOT EXISTS idx_dns_record_name ON dns_record FIELDS name UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS tenant_user SCHEMAFULL;
@@ -1587,6 +1598,8 @@ DEFINE FIELD IF NOT EXISTS auth0_sub ON tenant_user TYPE string;
 DEFINE FIELD IF NOT EXISTS tenant ON tenant_user TYPE record<tenant>;
 DEFINE FIELD IF NOT EXISTS role ON tenant_user TYPE string DEFAULT 'member';
 DEFINE FIELD IF NOT EXISTS created_at ON tenant_user TYPE option<datetime> DEFAULT time::now();
+-- D#4 soft-delete: tombstone (None = active row)
+DEFINE FIELD IF NOT EXISTS deleted_at ON tenant_user TYPE option<datetime>;
 -- B#2 fix: 旧 idx_tenant_user_sub は auth0_sub 単独 UNIQUE で multi-tenant
 -- ユーザー (1 Auth0 user → 複数 tenant) を block していた。 (auth0_sub, tenant)
 -- 複合 UNIQUE に切替。 REMOVE は schema 制約のみで data は不変。
@@ -1759,6 +1772,7 @@ mod tests {
             repository_url: Some("https://github.com/chronista-club/creo-memories".into()),
             created_at: None,
             updated_at: None,
+            deleted_at: None,
         };
         let created = db.create_project(&project).await.unwrap();
         assert!(created.id.is_some());
@@ -1818,6 +1832,7 @@ mod tests {
             lifecycle: None,
             created_at: None,
             updated_at: None,
+            deleted_at: None,
         };
         let created = db.register_server(&server).await.unwrap();
         assert!(created.id.is_some());
@@ -1898,6 +1913,7 @@ mod tests {
             lifecycle: None,
             created_at: None,
             updated_at: None,
+            deleted_at: None,
         };
         let created = db.register_server(&server).await.unwrap();
         assert!(created.id.is_some());
@@ -1968,6 +1984,7 @@ mod tests {
             tenant: tenant_id.clone(),
             role: "owner".into(),
             created_at: None,
+            deleted_at: None,
         };
         let created = db.create_tenant_user(&user).await.unwrap();
         assert!(created.id.is_some());
@@ -1989,6 +2006,7 @@ mod tests {
             tenant: tenant_id.clone(),
             role: "member".into(),
             created_at: None,
+            deleted_at: None,
         })
         .await
         .unwrap();
@@ -2062,6 +2080,7 @@ mod tests {
                 repository_url: None,
                 created_at: None,
                 updated_at: None,
+                deleted_at: None,
             })
             .await
             .unwrap();
@@ -2095,6 +2114,7 @@ mod tests {
                 lifecycle: None,
                 created_at: None,
                 updated_at: None,
+                deleted_at: None,
             })
             .await
             .unwrap();
@@ -2192,6 +2212,7 @@ mod tests {
             lifecycle: None,
             created_at: None,
             updated_at: None,
+            deleted_at: None,
         })
         .await
         .unwrap();
@@ -2356,6 +2377,7 @@ mod tests {
             lifecycle: None,
             created_at: None,
             updated_at: None,
+            deleted_at: None,
         };
         let created = db.register_server(&server).await.unwrap();
         assert_eq!(
@@ -2521,6 +2543,7 @@ mod tests {
                 lifecycle: None,
                 created_at: None,
                 updated_at: None,
+                deleted_at: None,
             })
             .await
             .unwrap();

--- a/crates/fleetflow-controlplane/src/handlers/dns.rs
+++ b/crates/fleetflow-controlplane/src/handlers/dns.rs
@@ -112,6 +112,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 proxied,
                                 created_at: None,
                                 updated_at: None,
+                                deleted_at: None,
                             };
 
                             match state.db.create_dns_record(&record).await {
@@ -296,6 +297,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                         proxied: cf_rec.proxied,
                                         created_at: None,
                                         updated_at: None,
+                                        deleted_at: None,
                                     };
                                     if state.db.create_dns_record(&record).await.is_ok() {
                                         imported += 1;

--- a/crates/fleetflow-controlplane/src/handlers/project.rs
+++ b/crates/fleetflow-controlplane/src/handlers/project.rs
@@ -82,6 +82,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     .map(String::from),
                                 created_at: None,
                                 updated_at: None,
+                                deleted_at: None,
                             };
 
                             match state.db.create_project(&project).await {

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -109,6 +109,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 lifecycle: None,
                                 created_at: None,
                                 updated_at: None,
+                                deleted_at: None,
                             };
 
                             match state.db.register_server(&server_model).await {
@@ -418,6 +419,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 lifecycle: None,
                                 created_at: None,
                                 updated_at: None,
+                                deleted_at: None,
                             };
 
                             match state.db.register_server(&server_model).await {

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -149,6 +149,8 @@ pub struct TenantUser {
     /// 役割: owner / admin / member（DB 上は String）
     pub role: String,
     pub created_at: Option<DateTime<Utc>>,
+    /// Soft-delete tombstone (None = active)
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 impl TenantUser {
@@ -219,6 +221,8 @@ pub struct Project {
     pub repository_url: Option<String>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
+    /// Soft-delete tombstone (None = active)
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, SurrealValue, Default)]
@@ -495,6 +499,8 @@ pub struct Server {
     pub lifecycle: Option<ServerLifecycle>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
+    /// Soft-delete tombstone (None = active)
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 // ─────────────────────────────────────────────
@@ -584,6 +590,8 @@ pub struct DnsRecord {
     pub proxied: bool,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
+    /// Soft-delete tombstone (None = active)
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 // ─────────────────────────────────────────────

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -656,6 +656,7 @@ async fn api_dns_sync(State(state): State<Arc<WebState>>, req: Request) -> impl 
                 proxied: cf_rec.proxied,
                 created_at: None,
                 updated_at: None,
+                deleted_at: None,
             };
             if state.app.db.create_dns_record(&record).await.is_ok() {
                 imported += 1;
@@ -1250,6 +1251,7 @@ async fn api_tenant_users_create(
         tenant: tenant_id,
         role: role_str.to_string(),
         created_at: None,
+        deleted_at: None,
     };
 
     match state.app.db.create_tenant_user(&user).await {


### PR DESCRIPTION
## Summary

Fix sprint-2 = **D#4 soft-delete migration** (score 82 の解消)。`feedback_no_data_deletion.md` rule (削除禁止 + 2 段階 rename) への準拠 + データ復旧可能性確保。

Hard `DELETE FROM` 4 sites を soft-delete pattern (`UPDATE SET deleted_at = time::now()` + `WHERE deleted_at IS NONE` filter) に切替。

## 変更点

### Schema (additive)

`crates/fleetflow-controlplane/src/db.rs` の SCHEMA SurQL に追加:

- `DEFINE FIELD IF NOT EXISTS deleted_at ON tenant_user TYPE option<datetime>;`
- `DEFINE FIELD IF NOT EXISTS deleted_at ON project TYPE option<datetime>;`
- `DEFINE FIELD IF NOT EXISTS deleted_at ON server TYPE option<datetime>;`
- `DEFINE FIELD IF NOT EXISTS deleted_at ON dns_record TYPE option<datetime>;`

既存 row はデフォルト `NONE` (active) として扱われる。idempotent。

### Model

`Project` / `Server` / `TenantUser` / `DnsRecord` に `pub deleted_at: Option<DateTime<Utc>>` 追加。

### DELETE → UPDATE (4 sites)

| 関数 | 旧 | 新 |
|------|---|---|
| delete_tenant_user | DELETE FROM tenant_user ... RETURN BEFORE | UPDATE tenant_user SET deleted_at = time::now() WHERE ... AND deleted_at IS NONE RETURN BEFORE |
| delete_project | DELETE FROM project ... | UPDATE project SET deleted_at = time::now() WHERE ... AND deleted_at IS NONE |
| delete_server | DELETE FROM server ... | UPDATE server SET deleted_at = time::now() WHERE ... AND deleted_at IS NONE |
| delete_dns_record | DELETE FROM dns_record ... RETURN BEFORE | UPDATE dns_record SET deleted_at = time::now() WHERE ... AND deleted_at IS NONE RETURN BEFORE |

Public API signatures は不変 (`Result<bool>` / `Result<()>`)。

### SELECT filter 追加 (10 sites)

`resolve_tenant_by_sub` / `resolve_tenant_user_scoped` / `list_tenant_users` / `get_project_by_slug` / `list_projects_by_tenant` / `find_project_by_tenant_and_slug` / `list_servers_by_tenant` / `list_all_servers` / `get_server_by_slug` / `list_dns_records_by_tenant` の 10 SELECT に `AND deleted_at IS NONE` (or 新 `WHERE`) を追加。

### 下流 struct-literal 15 sites

`db.rs` test fixtures + `handlers/{project,server,dns}.rs` + `fleetflowd/src/web.rs` の `Project` / `Server` / `TenantUser` / `DnsRecord` リテラルに `deleted_at: None` 補完 (`Default` 未派生のため必須)。

## Validation

- `cargo check -p fleetflow-controlplane --all-targets` → green
- `cargo clippy -p fleetflow-controlplane --all-targets -- -D warnings` → green (warning 0)
- `cargo test -p fleetflow-controlplane --lib` → **46 passed; 0 failed**

## Backward compat

- API client 視点では旧と等価: DELETE 呼び出し → 後続 GET/LIST で見えない (filter 効果)、`Result<bool>` の意味も同じ (1 回目 `true` / 2 回目 `false`)。
- 内部的に row を保持しているだけなので、復旧は `UPDATE ... SET deleted_at = NONE WHERE ...` で可能。
- DB 既存 row には `deleted_at` 欄がないが SurrealDB の `option<datetime>` は欠落 = `NONE` 扱いなので migration 不要。

## Test plan

- [x] cargo check (controlplane, --all-targets)
- [x] cargo clippy (-D warnings)
- [x] cargo test (lib, 46/46)
- [ ] integration smoke (next: dev tenant で `fleet cp project create → delete → list` 経路で動作確認)
- [ ] production schema migration 適用 (cp.fleetstage.cloud, additive なので無停止)

## 関連

- `feedback_no_data_deletion.md` (creo-memories: 削除なし原則)
- fix sprint-2 (sprint-1 = 907c30b3 の続編)

🤖 Generated with [Claude Code](https://claude.com/claude-code)