### PR TITLE
fix(scripts): sprint-3b — spawn-build-worker robustness (A#1+A#2+A#4)

### DIFF
--- a/scripts/idle-shutdown.sh
+++ b/scripts/idle-shutdown.sh
@@ -38,11 +38,27 @@ if [ -f "${DISABLE_FLAG}" ]; then
 fi
 
 # ─────────────────────────────────────────
-# 1b. 必須サービスの is-active check
+# 1b. 必須サービスの is-active check (install 済 service のみ)
 # ─────────────────────────────────────────
 # unit file の `After=` は ordering のみで gate にならない。
 # 必須サービスが落ちている場合は idle 判定を skip (誤 shutdown 回避)。
+#
+# ただし worker role 毎に install される service は異なる:
+#   - 通常 build worker:        docker + fleet-agent 両方 install
+#   - --no-fleet-agent worker:  docker のみ (fleet-agent 未 install)
+#   - docker 不使用 worker:     docker 自体未 install
+# Service が install されていない場合は check 対象外と判定 (skip しない)。
+# Install 済 service のみ active 必須を強制する。
+# (旧実装は両方 install 前提で `is-active` のみ確認していたため、 docker / fleet-agent
+#  未 install の worker では永続 skip = idle-shutdown 機能停止していた。)
 for svc in docker fleet-agent; do
+  # `systemctl list-unit-files <name>` は unit 不在でも rc=0 で
+  # "0 unit files listed." を出すため、 行マッチで実在を判定する。
+  if ! systemctl list-unit-files "${svc}.service" --no-legend 2>/dev/null \
+       | grep -q "^${svc}\.service"; then
+    # この worker では該当 service が install されていない → check 対象外
+    continue
+  fi
   if ! systemctl is-active --quiet "${svc}"; then
     log "skip: ${svc} is not active (idle check requires healthy stack)"
     exit 0
@@ -83,9 +99,13 @@ fi
 # epoch 0 fallback による偽陽性 idle 判定 を防ぐため、parse 失敗時は skip 扱い (安全側)。
 LAST_LINE=$(last --time-format=iso -n 5 2>/dev/null | grep -v '^$\|^wtmp\|^reboot' | head -1 || true)
 if [ -n "${LAST_LINE}" ]; then
-  # ISO 8601 timestamp は USER TTY HOST <ISO_TIME> ... の 4 列目
-  # 例: "mito pts/0  100.65.119.86 2026-04-28T22:48:11+09:00 ..."
-  LAST_TS=$(echo "${LAST_LINE}" | awk '{print $4}')
+  # `last` の出力は USER TTY HOST <ISO_TIME> ... 形式だが、 HOST が
+  # 空 / 空白 / IPv6 だと column position が揺れる (col-4 fixed parse は脆弱)。
+  # 全列を走査して ISO 8601 pattern (^YYYY-MM-DDT) に match する最初の field を
+  # 抽出することで、 HOST 列の有無に依存せず timestamp を取得する。
+  # 例 (HOST 有): "mito pts/0  100.65.119.86 2026-04-28T22:48:11+09:00 ..."
+  # 例 (HOST 無): "mito pts/1                 2026-04-29T08:00:00+09:00 ..."
+  LAST_TS=$(echo "${LAST_LINE}" | awk '{for(i=1;i<=NF;i++) if($i~/^[0-9]{4}-[0-9]{2}-[0-9]{2}T/) {print $i; exit}}')
   if [ -n "${LAST_TS}" ]; then
     LAST_EPOCH=$(date -d "${LAST_TS}" +%s 2>/dev/null || echo "")
     if [ -z "${LAST_EPOCH}" ] || [ "${LAST_EPOCH}" -le 0 ]; then

--- a/scripts/install-idle-shutdown.sh
+++ b/scripts/install-idle-shutdown.sh
@@ -67,11 +67,27 @@ if [ -f "${DISABLE_FLAG}" ]; then
 fi
 
 # ─────────────────────────────────────────
-# 1b. 必須サービスの is-active check
+# 1b. 必須サービスの is-active check (install 済 service のみ)
 # ─────────────────────────────────────────
 # unit file の `After=` は ordering のみで gate にならない。
 # 必須サービスが落ちている場合は idle 判定を skip (誤 shutdown 回避)。
+#
+# ただし worker role 毎に install される service は異なる:
+#   - 通常 build worker:        docker + fleet-agent 両方 install
+#   - --no-fleet-agent worker:  docker のみ (fleet-agent 未 install)
+#   - docker 不使用 worker:     docker 自体未 install
+# Service が install されていない場合は check 対象外と判定 (skip しない)。
+# Install 済 service のみ active 必須を強制する。
+# (旧実装は両方 install 前提で `is-active` のみ確認していたため、 docker / fleet-agent
+#  未 install の worker では永続 skip = idle-shutdown 機能停止していた。)
 for svc in docker fleet-agent; do
+  # `systemctl list-unit-files <name>` は unit 不在でも rc=0 で
+  # "0 unit files listed." を出すため、 行マッチで実在を判定する。
+  if ! systemctl list-unit-files "${svc}.service" --no-legend 2>/dev/null \
+       | grep -q "^${svc}\.service"; then
+    # この worker では該当 service が install されていない → check 対象外
+    continue
+  fi
   if ! systemctl is-active --quiet "${svc}"; then
     log "skip: ${svc} is not active (idle check requires healthy stack)"
     exit 0
@@ -112,9 +128,13 @@ fi
 # epoch 0 fallback による偽陽性 idle 判定 を防ぐため、parse 失敗時は skip 扱い (安全側)。
 LAST_LINE=$(last --time-format=iso -n 5 2>/dev/null | grep -v '^$\|^wtmp\|^reboot' | head -1 || true)
 if [ -n "${LAST_LINE}" ]; then
-  # ISO 8601 timestamp は USER TTY HOST <ISO_TIME> ... の 4 列目
-  # 例: "mito pts/0  100.65.119.86 2026-04-28T22:48:11+09:00 ..."
-  LAST_TS=$(echo "${LAST_LINE}" | awk '{print $4}')
+  # `last` の出力は USER TTY HOST <ISO_TIME> ... 形式だが、 HOST が
+  # 空 / 空白 / IPv6 だと column position が揺れる (col-4 fixed parse は脆弱)。
+  # 全列を走査して ISO 8601 pattern (^YYYY-MM-DDT) に match する最初の field を
+  # 抽出することで、 HOST 列の有無に依存せず timestamp を取得する。
+  # 例 (HOST 有): "mito pts/0  100.65.119.86 2026-04-28T22:48:11+09:00 ..."
+  # 例 (HOST 無): "mito pts/1                 2026-04-29T08:00:00+09:00 ..."
+  LAST_TS=$(echo "${LAST_LINE}" | awk '{for(i=1;i<=NF;i++) if($i~/^[0-9]{4}-[0-9]{2}-[0-9]{2}T/) {print $i; exit}}')
   if [ -n "${LAST_TS}" ]; then
     LAST_EPOCH=$(date -d "${LAST_TS}" +%s 2>/dev/null || echo "")
     if [ -z "${LAST_EPOCH}" ] || [ "${LAST_EPOCH}" -le 0 ]; then

--- a/scripts/spawn-build-worker.sh
+++ b/scripts/spawn-build-worker.sh
@@ -328,6 +328,32 @@ echo "  server_id:  ${SERVER_ID}"
 echo "  public_ip:  ${PUBLIC_IP}"
 echo ""
 
+# ─────────────────────────────────────────
+# Phase 2.5. ERR trap install (Phase 4/5/5.5 SSH 失敗時の cleanup hint)
+# ─────────────────────────────────────────
+# Phase 4 (provision-worker-base.sh) / Phase 5 (worker-init.sh) / Phase 5.5
+# (fleet-agent install) の SSH コマンドが set -e で即 exit すると、
+# server + 1Password item が dangling のまま user に hint が表示されない。
+# ERR trap で uncaught error 時に cleanup commands を stderr に吐く。
+# (Phase 0/1/2 の explicit `echo + exit 1` path は trap 登録前に exit するので
+#  二重出力にはならない。 set -e による即 exit のみ catch する。)
+trap_cleanup_on_err() {
+  local rc=$?
+  echo "" >&2
+  echo "=== ERROR (rc=${rc}) — server may be left dangling ===" >&2
+  if [ -n "${SERVER_ID:-}" ]; then
+    echo "  cleanup: usacloud server delete -y --with-disks --zone ${ZONE} ${SERVER_ID}" >&2
+  fi
+  if [ -n "${PW_ITEM_ID:-}" ]; then
+    echo "           op item delete ${PW_ITEM_ID} --vault ${OP_VAULT}" >&2
+  fi
+  if [ -n "${TS_IP:-}" ]; then
+    echo "  注: Tailscale node ${NAME}-ts (${TS_IP}) が tailnet に残る可能性、 必要なら admin console で remove" >&2
+  fi
+}
+trap trap_cleanup_on_err ERR
+set -E  # ERR trap を function / subshell にも propagate
+
 if [ "${DRY_RUN}" -eq 1 ]; then
   echo "=== DRY-RUN 完了 ==="
   echo "  provision/init/idle-shutdown は skip"


### PR DESCRIPTION
## Summary

fix-sprint-3b では C9 (spawn-build-worker robustness) の高 score 3 件を解消する。

- **A#1 (score 90)**: `spawn-build-worker.sh` の Phase 4/5/5.5 SSH 失敗時に `set -e` で即 exit するため、 server + 1Password item の dangling cleanup hint が出ない問題を ERR trap で修正
- **A#2 (score 82)**: `idle-shutdown.sh` の `last --time-format=iso` 出力 col-4 awk parse が HOST 列空白 / IPv6 / 異版 util-linux で揺れる脆弱性を ISO 8601 regex match で修正
- **A#4 (score 78)**: `idle-shutdown.sh` の必須 service チェックが docker / fleet-agent 両 active 必須で、`--no-fleet-agent` build worker 等で永続 skip = idle-shutdown 機能停止になる問題を install 済 service のみ強制する形に修正

## 変更点 (file-by-file)

### `scripts/spawn-build-worker.sh` (+26)
- Phase 2 (SERVER_ID + PUBLIC_IP 確定) 直後に `Phase 2.5: ERR trap install` セクションを追加
- `trap_cleanup_on_err()` で `${SERVER_ID}` / `${PW_ITEM_ID}` / `${TS_IP}` が set のものだけ cleanup commands を stderr に出力
- `set -E` で function / subshell にも trap を propagate
- Phase 0/1/2 の explicit `echo + exit 1` path は trap 登録前に exit するので二重出力にならない
- `--help` 経路 (Phase 2 到達前) では trap 登録されないため smoke test も green

### `scripts/idle-shutdown.sh` (+22 / -4)
- **A#4**: `for svc in docker fleet-agent` ループに `systemctl list-unit-files <svc>.service` 実在チェックを追加。 unit が install されていなければ `continue` で check 対象外と判定 (`systemctl list-unit-files` は unit 不在でも rc=0 なので行マッチで判定)
- **A#2**: `LAST_TS=$(echo "${LAST_LINE}" | awk '{print $4}')` を `awk '{for(i=1;i<=NF;i++) if(\$i~/^[0-9]{4}-[0-9]{2}-[0-9]{2}T/) {print \$i; exit}}'` に変更し、 全列走査で ISO 8601 timestamp pattern マッチ最初の field を抽出 (列位置非依存)
- 既存の parse 失敗時 safe-side `exit 0` skip 動作は不変

### `scripts/install-idle-shutdown.sh` (+22 / -4)
- 生成物。 `scripts/build-install-idle-shutdown.sh` で再生成し、 source `idle-shutdown.sh` の A#2 + A#4 fix を SCRIPT_INNER heredoc に同期

## Validation

- `bash -n scripts/spawn-build-worker.sh` → OK
- `bash -n scripts/idle-shutdown.sh` → OK
- `bash -n scripts/install-idle-shutdown.sh` → OK
- `bash -n scripts/build-install-idle-shutdown.sh` → OK
- `./scripts/spawn-build-worker.sh --help` → 正常出力 (ERR trap 未発火)
- `cargo fmt --all -- --check` → rc=0 (Rust 触らないが念のため)
- 3-file DRY: source `idle-shutdown.sh` と generated `install-idle-shutdown.sh` の SCRIPT_INNER 内容一致を grep で確認 (A#2 + A#4 両方 reflect)

## 関連

- fix sprint plan: sprint-1 (#163) → sprint-1 residuals (#164) → sprint-2 C4 (#165) → sprint-3a C5+C6 (#166) → **sprint-3b C9 (this PR)**
- 修正対象 issue: A#1 (score 90) + A#2 (score 82) + A#4 (score 78) — C9 (spawn-build-worker robustness) cluster

## Test plan

- [ ] CI 全 green を確認
- [ ] (optional) build-04 等で実 spawn を 1 回流し、 A#1 ERR trap 経路 (例: `--fleet-cp-endpoint` を不正値にして Phase 5.5 を意図的に失敗させ) cleanup hint が出ることを確認
- [ ] (optional) `--no-fleet-agent` build worker 上で `systemctl start idle-shutdown.service` を手動 fire し、 docker / fleet-agent 未 install 環境で skip しないこと (= 通常パスを進む) を確認