### PR TITLE
fix(fleet-agent): sprint-5b — surface deploy log send failures (D#8)

### DIFF
--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -192,8 +192,12 @@ async fn handle_deploy(
     );
 
     // 蓄積されたログ行を CP に送信
+    // D#8 fix: 旧実装は `let _ = ...send_event(...)` で silent discard していたため
+    // CP channel が落ちている等で deploy log が全 loss しても何も log に出ず、
+    // 運用 debug が困難だった。 失敗カウントを集計して warn 1 行で可視化。
+    let mut failed_log_sends: usize = 0;
     for line in &log_lines {
-        let _ = channel_for_log
+        if channel_for_log
             .send_event(
                 "deploy_log",
                 &json!({
@@ -201,7 +205,18 @@ async fn handle_deploy(
                     "line": line,
                 }),
             )
-            .await;
+            .await
+            .is_err()
+        {
+            failed_log_sends += 1;
+        }
+    }
+    if failed_log_sends > 0 {
+        warn!(
+            failed = failed_log_sends,
+            total = log_lines.len(),
+            "deploy log lines lost (CP channel error)"
+        );
     }
 
     // 最終結果を Response として返す


### PR DESCRIPTION
## Summary

D#8 (score 76、 fix sprint final issue) の解消。

\`crates/fleet-agent/src/agent.rs:195-205\` の deploy log 送信 loop で \`let _ = ...send_event(...).await\` で silent discard していたため、 CP channel が落ちている等で deploy log が全 loss しても何も log に出ず、 運用 debug が困難だった。

## 修正

failure counter を per-line で集計、 loop 終了時に loss があれば \`tracing::warn!(failed, total, ...)\` 1 行で可視化する。 silent discard → ops visibility。

## Validation

- [x] \`cargo check -p fleet-agent --all-targets\` 20s green
- [x] \`cargo clippy -p fleet-agent --all-targets -- -D warnings\` green
- [x] \`cargo fmt --all -- --check\` green
- [ ] CI 全 green

## fix sprint 完走

これで moody-blues 4 scope review (26 issue) のうち **〜23 issue (≒88%)** を fix sprint で消化。 残 ~3 件は score 75 未満 nit (未対象判定)、 sprint plan 完走。

🤖 Generated with [Claude Code](https://claude.com/claude-code)