### PR TITLE
feat(core,cli): tenant block in fleet.kdl + deploy tenant_slug 解決優先度

### DIFF
--- a/crates/fleetflow-container/src/converter.rs
+++ b/crates/fleetflow-container/src/converter.rs
@@ -375,6 +375,7 @@ mod tests {
             servers: HashMap::new(),
             registry: None,
             variables: HashMap::new(),
+            tenant: None,
         };
 
         let result = get_stage_services(&flow, "local").unwrap();
@@ -393,6 +394,7 @@ mod tests {
             servers: HashMap::new(),
             registry: None,
             variables: HashMap::new(),
+            tenant: None,
         };
 
         let result = get_stage_services(&flow, "prod");

--- a/crates/fleetflow-container/src/engine.rs
+++ b/crates/fleetflow-container/src/engine.rs
@@ -539,6 +539,7 @@ mod tests {
             servers: std::collections::HashMap::new(),
             registry: None,
             variables: std::collections::HashMap::new(),
+            tenant: None,
         }
     }
 

--- a/crates/fleetflow-container/tests/engine_test.rs
+++ b/crates/fleetflow-container/tests/engine_test.rs
@@ -31,6 +31,7 @@ fn make_flow(services: Vec<(&str, Service)>, stage_services: Vec<&str>) -> Flow 
         servers: HashMap::new(),
         registry: None,
         variables: HashMap::new(),
+        tenant: None,
     }
 }
 

--- a/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
+++ b/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
@@ -87,6 +87,7 @@ fn make_test_flow() -> Flow {
         servers: HashMap::new(),
         registry: None,
         variables: HashMap::new(),
+        tenant: None,
     }
 }
 

--- a/crates/fleetflow-core/src/model/flow.rs
+++ b/crates/fleetflow-core/src/model/flow.rs
@@ -3,6 +3,7 @@
 use super::cloud::{CloudProvider, ServerResource};
 use super::service::Service;
 use super::stage::Stage;
+use super::tenant::TenantSpec;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -30,4 +31,11 @@ pub struct Flow {
     /// プロジェクト共通の変数（全ステージで使用可能）
     #[serde(default)]
     pub variables: HashMap<String, String>,
+    /// fleet.kdl で宣言された tenant 情報 (= project の所有 tenant)。
+    ///
+    /// `None` の場合 deploy CLI が `creds.tenant_slug` (Auth0 org context) や
+    /// "default" にフォールバック。 `Some` のとき deploy 時の tenant_slug は
+    /// この値が optimal な権威を持つ (CLI flag による override は可)。
+    #[serde(default)]
+    pub tenant: Option<TenantSpec>,
 }

--- a/crates/fleetflow-core/src/model/mod.rs
+++ b/crates/fleetflow-core/src/model/mod.rs
@@ -9,6 +9,7 @@ mod port;
 mod process;
 mod service;
 mod stage;
+mod tenant;
 mod volume;
 
 // Re-exports
@@ -18,6 +19,7 @@ pub use port::*;
 pub use process::*;
 pub use service::*;
 pub use stage::*;
+pub use tenant::*;
 pub use volume::*;
 
 #[cfg(test)]
@@ -55,6 +57,7 @@ mod tests {
             servers: HashMap::new(),
             registry: None,
             variables: HashMap::new(),
+            tenant: None,
         };
 
         assert_eq!(flow.name, "my-project");
@@ -80,6 +83,7 @@ mod tests {
             servers: HashMap::new(),
             registry: None,
             variables: HashMap::new(),
+            tenant: None,
         };
 
         assert_eq!(flow.services.len(), 1);

--- a/crates/fleetflow-core/src/model/tenant.rs
+++ b/crates/fleetflow-core/src/model/tenant.rs
@@ -1,0 +1,43 @@
+//! Tenant 宣言モデル
+//!
+//! `tenant "<slug>" { name "..." plan "..." auth0_org_id "..." }` 構文を
+//! Flow に attach するための spec。 fleet.kdl 上で project の所有権 (どの tenant の
+//! 配下に project が属するか) を **declarative** に記述するための層。
+//!
+//! deploy 時の tenant_slug 解決優先度 (deploy.rs):
+//!   1. CLI flag `--tenant <slug>` (override)
+//!   2. fleet.kdl `tenant "<slug>"` block (= TenantSpec.slug)
+//!   3. CLI auth context (`creds.tenant_slug`)
+//!   4. "default"
+
+use serde::{Deserialize, Serialize};
+
+/// fleet.kdl で宣言された tenant 情報。
+///
+/// 全 field は controlplane の `tenant` table と 1:1 対応:
+/// - `slug` は識別子 (URL safe、 unique)
+/// - `name` は表示用、 省略時は slug を流用
+/// - `auth0_org_id` は Auth0 organization 連携が必要な tenant のみ設定
+/// - `plan` は billing tier (例: `plus` / `pro` / `team` / `platform`、 自由文字列)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TenantSpec {
+    pub slug: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth0_org_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+}
+
+impl TenantSpec {
+    /// slug のみで最小構成 (name / auth0_org_id / plan は controlplane 側 default)。
+    pub fn from_slug(slug: impl Into<String>) -> Self {
+        Self {
+            slug: slug.into(),
+            name: None,
+            auth0_org_id: None,
+            plan: None,
+        }
+    }
+}

--- a/crates/fleetflow-core/src/parser/mod.rs
+++ b/crates/fleetflow-core/src/parser/mod.rs
@@ -7,18 +7,20 @@ mod cloud;
 mod port;
 mod service;
 mod stage;
+mod tenant;
 mod volume;
 
 // 内部で使用するパース関数
 use cloud::parse_provider;
 use service::parse_service;
 use stage::parse_stage;
+use tenant::parse_tenant;
 
 // 外部クレートから再利用可能なパース関数
 pub use cloud::parse_server;
 
 use crate::error::{FlowError, Result};
-use crate::model::{Flow, Service};
+use crate::model::{Flow, Service, TenantSpec};
 use crate::template::{TemplateProcessor, extract_variables};
 use kdl::KdlDocument;
 use std::collections::{HashMap, HashSet};
@@ -194,6 +196,7 @@ fn parse_kdl_string_raw_with_stage(
     let mut variables: HashMap<String, String> = HashMap::new();
     let mut name = default_name;
     let mut registry: Option<String> = None;
+    let mut tenant: Option<TenantSpec> = None;
 
     for node in doc.nodes() {
         match node.name().value() {
@@ -256,6 +259,11 @@ fn parse_kdl_string_raw_with_stage(
                     registry = Some(reg.to_string());
                 }
             }
+            "tenant" => {
+                // fleet.kdl で project の所有 tenant を declarative に宣言
+                // (last-wins、 同 file 内に複数あれば最後のものが採用される)
+                tenant = Some(parse_tenant(node)?);
+            }
             _ => {
                 // 不明なノードはスキップ（projectなどの追加ノードも許可）
             }
@@ -286,6 +294,7 @@ fn parse_kdl_string_raw_with_stage(
         servers,
         registry,
         variables,
+        tenant,
     })
 }
 

--- a/crates/fleetflow-core/src/parser/tenant.rs
+++ b/crates/fleetflow-core/src/parser/tenant.rs
@@ -1,0 +1,136 @@
+//! `tenant "<slug>" { ... }` ノードのパース。
+//!
+//! 文法:
+//! ```kdl
+//! tenant "<slug>" {
+//!     name "..."           // 表示名 (省略時は slug を流用)
+//!     auth0_org_id "..."   // Auth0 organization 連携 (省略可)
+//!     plan "..."           // billing tier 識別子 (例: plus / pro / team / platform)
+//! }
+//! ```
+//!
+//! tenant block は **fleet.kdl 1 ファイルに 1 つだけ** 配置される想定。
+//! 同 file 内に複数 tenant block が現れた場合の merge は今は未定義 (parser は last-wins)。
+
+use crate::error::{FlowError, Result};
+use crate::model::TenantSpec;
+use kdl::KdlNode;
+
+/// `tenant "<slug>" { ... }` ノードを解析して `TenantSpec` を返す。
+///
+/// slug は entry 1 件目の string 必須。 child block の各 key (name / auth0_org_id /
+/// plan) は string 1 件目を抽出。 不明な key は無視 (forward-compat)。
+pub fn parse_tenant(node: &KdlNode) -> Result<TenantSpec> {
+    let slug = node
+        .entries()
+        .first()
+        .and_then(|e| e.value().as_string())
+        .ok_or_else(|| FlowError::InvalidConfig("tenant ノードに slug がありません".into()))?
+        .to_string();
+
+    let mut name: Option<String> = None;
+    let mut auth0_org_id: Option<String> = None;
+    let mut plan: Option<String> = None;
+
+    if let Some(children) = node.children() {
+        for child in children.nodes() {
+            let key = child.name().value();
+            let value = child
+                .entries()
+                .first()
+                .and_then(|e| e.value().as_string())
+                .map(|s| s.to_string());
+            match key {
+                "name" => name = value,
+                "auth0_org_id" => auth0_org_id = value,
+                "plan" => plan = value,
+                _ => {
+                    // 不明 key は無視 (forward-compat)
+                }
+            }
+        }
+    }
+
+    Ok(TenantSpec {
+        slug,
+        name,
+        auth0_org_id,
+        plan,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kdl::KdlDocument;
+
+    fn first_tenant_node(kdl: &str) -> KdlNode {
+        let doc: KdlDocument = kdl.parse().unwrap();
+        doc.nodes()
+            .iter()
+            .find(|n| n.name().value() == "tenant")
+            .cloned()
+            .expect("tenant ノードが見つかりません")
+    }
+
+    #[test]
+    fn parse_minimal_slug_only() {
+        let node = first_tenant_node(r#"tenant "hq""#);
+        let spec = parse_tenant(&node).unwrap();
+        assert_eq!(spec.slug, "hq");
+        assert_eq!(spec.name, None);
+        assert_eq!(spec.auth0_org_id, None);
+        assert_eq!(spec.plan, None);
+    }
+
+    #[test]
+    fn parse_full_block() {
+        let node = first_tenant_node(
+            r#"tenant "hq" {
+                name "FleetStage HQ"
+                auth0_org_id "org_abc"
+                plan "platform"
+            }"#,
+        );
+        let spec = parse_tenant(&node).unwrap();
+        assert_eq!(spec.slug, "hq");
+        assert_eq!(spec.name.as_deref(), Some("FleetStage HQ"));
+        assert_eq!(spec.auth0_org_id.as_deref(), Some("org_abc"));
+        assert_eq!(spec.plan.as_deref(), Some("platform"));
+    }
+
+    #[test]
+    fn parse_partial_block_only_name() {
+        let node = first_tenant_node(
+            r#"tenant "anycreative" {
+                name "Anycreative Inc"
+            }"#,
+        );
+        let spec = parse_tenant(&node).unwrap();
+        assert_eq!(spec.slug, "anycreative");
+        assert_eq!(spec.name.as_deref(), Some("Anycreative Inc"));
+        assert_eq!(spec.auth0_org_id, None);
+        assert_eq!(spec.plan, None);
+    }
+
+    #[test]
+    fn parse_unknown_key_is_ignored() {
+        let node = first_tenant_node(
+            r#"tenant "hq" {
+                name "FleetStage HQ"
+                future_field "something"
+            }"#,
+        );
+        let spec = parse_tenant(&node).unwrap();
+        assert_eq!(spec.slug, "hq");
+        assert_eq!(spec.name.as_deref(), Some("FleetStage HQ"));
+        // future_field は無視される
+    }
+
+    #[test]
+    fn parse_missing_slug_returns_error() {
+        let node = first_tenant_node(r#"tenant"#);
+        let result = parse_tenant(&node);
+        assert!(result.is_err());
+    }
+}

--- a/crates/fleetflow/src/commands/deploy.rs
+++ b/crates/fleetflow/src/commands/deploy.rs
@@ -138,6 +138,7 @@ pub async fn handle(
     no_prune: bool,
     yes: bool,
     dry_run: bool,
+    tenant_override: Option<String>,
 ) -> anyhow::Result<()> {
     println!("{}", "デプロイを開始します...".blue().bold());
     utils::print_loaded_config_files(project_root);
@@ -219,7 +220,15 @@ pub async fn handle(
         let is_remote = !stage_config.servers.is_empty();
 
         if is_remote {
-            deploy_remote(config, &stage_name, &container_names, no_pull, no_prune).await?;
+            deploy_remote(
+                config,
+                &stage_name,
+                &container_names,
+                no_pull,
+                no_prune,
+                tenant_override.as_deref(),
+            )
+            .await?;
         } else {
             deploy_local(config, &stage_name, &container_names, no_pull, no_prune).await?;
         }
@@ -351,12 +360,16 @@ async fn deploy_local(
 }
 
 /// リモートデプロイ — CP 経由で DeployEngine を実行
+///
+/// `tenant_override` は CLI flag `--tenant <slug>` 由来 (省略時 None)。
+/// tenant 解決優先度は [`resolve_tenant_slug`] 参照。
 async fn deploy_remote(
     config: &fleetflow_core::Flow,
     stage_name: &str,
     target_services: &[String],
     no_pull: bool,
     no_prune: bool,
+    tenant_override: Option<&str>,
 ) -> anyhow::Result<()> {
     use super::cp_client;
     use serde_json::json;
@@ -364,6 +377,10 @@ async fn deploy_remote(
     println!();
     println!("{}", "Control Plane に接続中...".blue());
     let (client, creds) = cp_client::connect().await?;
+
+    let tenant_slug =
+        resolve_tenant_slug(tenant_override, config, creds.tenant_slug.as_deref());
+    println!("テナント: {}", tenant_slug.cyan());
 
     let request = DeployRequest {
         flow: config.clone(),
@@ -378,7 +395,7 @@ async fn deploy_remote(
         "deploy",
         "execute",
         json!({
-            "tenant_slug": creds.tenant_slug.as_deref().unwrap_or("default"),
+            "tenant_slug": tenant_slug,
             "project_slug": config.name,
             "request": serde_json::to_value(&request)?,
         }),
@@ -406,4 +423,95 @@ async fn deploy_remote(
     }
 
     Ok(())
+}
+
+/// tenant_slug を解決する。
+///
+/// 優先度 (高 → 低):
+/// 1. CLI flag `--tenant <slug>` (`cli_override`) — one-shot deploy 用
+/// 2. fleet.kdl `tenant "<slug>"` block (`config.tenant.slug`) — declarative SSOT
+/// 3. CLI auth context (`creds_tenant`、 `fleetflow login` 時に Auth0 org から取得)
+/// 4. `"default"` — 最終 fallback (旧挙動互換)
+///
+/// 副作用なし、 純関数。 tenant が未設定でも deploy 自体は通る (controlplane 側で
+/// "default" tenant が無いと CREATE される or エラーになるが、 ここでは判断しない)。
+fn resolve_tenant_slug(
+    cli_override: Option<&str>,
+    config: &fleetflow_core::Flow,
+    creds_tenant: Option<&str>,
+) -> String {
+    if let Some(s) = cli_override.filter(|s| !s.is_empty()) {
+        return s.to_string();
+    }
+    if let Some(spec) = &config.tenant {
+        return spec.slug.clone();
+    }
+    if let Some(s) = creds_tenant.filter(|s| !s.is_empty()) {
+        return s.to_string();
+    }
+    "default".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fleetflow_core::TenantSpec;
+    use fleetflow_core::model::Flow;
+    use std::collections::HashMap;
+
+    fn flow_with_tenant(tenant: Option<TenantSpec>) -> Flow {
+        Flow {
+            name: "test".to_string(),
+            services: HashMap::new(),
+            stages: HashMap::new(),
+            providers: HashMap::new(),
+            servers: HashMap::new(),
+            registry: None,
+            variables: HashMap::new(),
+            tenant,
+        }
+    }
+
+    #[test]
+    fn cli_override_wins_over_kdl_and_creds() {
+        let flow = flow_with_tenant(Some(TenantSpec::from_slug("hq")));
+        let result = resolve_tenant_slug(Some("override"), &flow, Some("anycreative"));
+        assert_eq!(result, "override");
+    }
+
+    #[test]
+    fn kdl_block_wins_over_creds() {
+        let flow = flow_with_tenant(Some(TenantSpec::from_slug("hq")));
+        let result = resolve_tenant_slug(None, &flow, Some("anycreative"));
+        assert_eq!(result, "hq");
+    }
+
+    #[test]
+    fn creds_used_when_kdl_missing() {
+        let flow = flow_with_tenant(None);
+        let result = resolve_tenant_slug(None, &flow, Some("anycreative"));
+        assert_eq!(result, "anycreative");
+    }
+
+    #[test]
+    fn default_when_all_missing() {
+        let flow = flow_with_tenant(None);
+        let result = resolve_tenant_slug(None, &flow, None);
+        assert_eq!(result, "default");
+    }
+
+    #[test]
+    fn empty_cli_override_falls_through_to_kdl() {
+        // 空文字 --tenant "" は無視 (clap の default=None と同視)
+        let flow = flow_with_tenant(Some(TenantSpec::from_slug("hq")));
+        let result = resolve_tenant_slug(Some(""), &flow, None);
+        assert_eq!(result, "hq");
+    }
+
+    #[test]
+    fn empty_creds_falls_through_to_default() {
+        let flow = flow_with_tenant(None);
+        let result = resolve_tenant_slug(None, &flow, Some(""));
+        assert_eq!(result, "default");
+    }
 }

--- a/crates/fleetflow/src/commands/deploy.rs
+++ b/crates/fleetflow/src/commands/deploy.rs
@@ -378,8 +378,7 @@ async fn deploy_remote(
     println!("{}", "Control Plane に接続中...".blue());
     let (client, creds) = cp_client::connect().await?;
 
-    let tenant_slug =
-        resolve_tenant_slug(tenant_override, config, creds.tenant_slug.as_deref());
+    let tenant_slug = resolve_tenant_slug(tenant_override, config, creds.tenant_slug.as_deref());
     println!("テナント: {}", tenant_slug.cyan());
 
     let request = DeployRequest {

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -223,6 +223,9 @@ enum Commands {
         /// 実行せずに実行計画のみ表示
         #[arg(long)]
         dry_run: bool,
+        /// テナント slug を override (省略時は fleet.kdl の `tenant` block → CLI auth context → "default" の順で解決)
+        #[arg(long)]
+        tenant: Option<String>,
     },
 
     // ── Admin ──────────────────────────────────
@@ -939,6 +942,7 @@ async fn main() -> anyhow::Result<()> {
             no_prune,
             yes,
             dry_run,
+            tenant,
         } => {
             let stage = resolve_stage(stage, stage_flag);
             commands::deploy::handle(
@@ -950,6 +954,7 @@ async fn main() -> anyhow::Result<()> {
                 no_prune,
                 yes,
                 dry_run,
+                tenant,
             )
             .await?;
         }


### PR DESCRIPTION
## Summary

- fleet.kdl に top-level `tenant "<slug>" { ... }` block を追加 — project の所有 tenant を **declarative に repo に commit** できる
- deploy CLI の tenant_slug 解決を **kdl-first** に切替 — 旧 `creds → default` 経路を保ちつつ、 kdl block を間に差し込み
- `fleet deploy --tenant <slug>` で one-shot override 可能

## 動機

現状 `fleetflow/src/commands/deploy.rs` の tenant_slug は CLI auth context から取得 (`creds.tenant_slug.unwrap_or("default")`)、 fleet.kdl では project 名のみが宣言されてた。 これだと:

- 「どの tenant に deploy されるか」 が repo から見えない (CLI の auth state 依存)
- multi-tenant な repo で CLI 切替を強制される
- 自社 platform (= 自分自身を tenant 扱い) のような特殊 case が表現できない

`tenant` block を kdl 上に置けば、 GitOps 的に tenant 所有権が明示され、 deploy の再現性が上がる。

## 追加文法

\`\`\`kdl
tenant "hq" {
    name "FleetStage HQ"
    plan "platform"
    // auth0_org_id "org_..." (省略可)
}

project "fleetstage"
\`\`\`

- fleet.kdl 1 file に 1 block の想定 (last-wins)
- 不明 child key は forward-compat で無視
- 旧 fleet.kdl (tenant block なし) は完全互換 — deploy CLI は既存経路で fallback

## tenant_slug 解決優先度 (高 → 低)

| 順 | 出処 | 用途 |
|---|---|---|
| 1 | CLI flag \`--tenant <slug>\` | one-shot override (試験 deploy 等) |
| 2 | fleet.kdl \`tenant "<slug>"\` | declarative SSOT (推奨) |
| 3 | CLI auth context (\`creds.tenant_slug\`) | 旧挙動 (login 時 Auth0 org) |
| 4 | \`"default"\` | 最終 fallback |

## 構成

- \`fleetflow-core/src/model/tenant.rs\` (new) — TenantSpec struct (slug / name / auth0_org_id / plan)
- \`fleetflow-core/src/parser/tenant.rs\` (new) — parse_tenant 関数 + 5 test
- \`fleetflow-core/src/model/flow.rs\` — \`Flow.tenant: Option<TenantSpec>\` 追加
- \`fleetflow-core/src/parser/mod.rs\` — top-level node \`"tenant" =>\` branch
- \`fleetflow/src/commands/deploy.rs\` — \`resolve_tenant_slug\` 純関数 + 6 test、 \`--tenant\` flag
- 既存 test の Flow リテラル構築に \`tenant: None\` 追記 (engine / converter / engine_test / deploy_execute_test)

## Test plan

- [x] fleetflow-core lib: **119 passed** (parser tenant test 5 件含む、 既存 regression なし)
- [x] fleetflow CLI bin: **6 passed** (resolve_tenant_slug 全 case)
  - cli_override_wins_over_kdl_and_creds
  - kdl_block_wins_over_creds
  - creds_used_when_kdl_missing
  - default_when_all_missing
  - empty_cli_override_falls_through_to_kdl
  - empty_creds_falls_through_to_default
- [ ] CI で workspace 全 test 通過
- [ ] fleetstage 側で \`tenant "hq"\` 宣言 + deploy 実走で end-to-end 確認 (この PR merge 後)

## Backward compatibility

旧 fleet.kdl は無修正で動く。 (3)(4) の経路がそのまま fallback されるため、 既存 deploy には影響なし。 新規 \`tenant\` block を追加した時点で (2) 経路が active 化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)