### PR TITLE
feat(deploy): dry-run plan に解決済 tenant_slug + source 表示

### DIFF
--- a/crates/fleetflow/src/commands/deploy.rs
+++ b/crates/fleetflow/src/commands/deploy.rs
@@ -7,16 +7,27 @@ use fleetflow_container::{DeployEngine, DeployEvent, DeployRequest};
 use crate::utils::is_sensitive_key;
 
 /// dry-run モードでデプロイ計画を表示する
+///
+/// `tenant_override` は CLI flag `--tenant <slug>` の値。 CP creds は呼ばない
+/// (dry-run は無接続) ので、 解決優先度のうち (1) と (2) のみが評価される
+/// — `(creds → "default")` への fallback は実 deploy で初めて確定する。
 fn print_dry_run_plan(
     config: &fleetflow_core::Flow,
     stage_name: &str,
     target_services: &[String],
+    tenant_override: Option<&str>,
 ) -> anyhow::Result<()> {
     println!(
         "{}",
         format!("[dry-run] ステージ '{}' のデプロイ計画:", stage_name)
             .yellow()
             .bold()
+    );
+
+    println!();
+    println!(
+        "  テナント: {}",
+        format_dry_run_tenant(tenant_override, config)
     );
 
     let network_name = fleetflow_container::get_network_name(&config.name, stage_name);
@@ -186,7 +197,12 @@ pub async fn handle(
 
     // dry-run モードの場合は実行計画を表示して終了
     if dry_run {
-        return print_dry_run_plan(config, &stage_name, &target_services);
+        return print_dry_run_plan(
+            config,
+            &stage_name,
+            &target_services,
+            tenant_override.as_deref(),
+        );
     }
 
     // 確認（--yesが指定されていない場合）
@@ -451,6 +467,23 @@ fn resolve_tenant_slug(
     "default".to_string()
 }
 
+/// dry-run 表示用に「テナント解決」 結果と source を 1 行に整形する。
+///
+/// dry-run は CP に接続しないため `creds_tenant` は常に `None` 扱い。
+/// ユーザーには 「決定値 + どこから来たか」 を可視化して、 deploy 前に
+/// 想定通りの tenant に向くか確認できるようにする。
+fn format_dry_run_tenant(cli_override: Option<&str>, config: &fleetflow_core::Flow) -> String {
+    let slug = resolve_tenant_slug(cli_override, config, None);
+    let source = if cli_override.is_some_and(|s| !s.is_empty()) {
+        "CLI flag --tenant"
+    } else if config.tenant.is_some() {
+        "fleet.kdl tenant block"
+    } else {
+        "fallback (creds 未確認 or default)"
+    };
+    format!("{} ({})", slug.cyan(), source)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,5 +545,32 @@ mod tests {
         let flow = flow_with_tenant(None);
         let result = resolve_tenant_slug(None, &flow, Some(""));
         assert_eq!(result, "default");
+    }
+
+    // ── format_dry_run_tenant ─────────────────────────
+    // 色 escape 文字列を含むので `contains` で slug + source を確認
+
+    #[test]
+    fn dry_run_tenant_kdl_block_source() {
+        let flow = flow_with_tenant(Some(TenantSpec::from_slug("hq")));
+        let formatted = format_dry_run_tenant(None, &flow);
+        assert!(formatted.contains("hq"));
+        assert!(formatted.contains("fleet.kdl tenant block"));
+    }
+
+    #[test]
+    fn dry_run_tenant_cli_override_source() {
+        let flow = flow_with_tenant(Some(TenantSpec::from_slug("hq")));
+        let formatted = format_dry_run_tenant(Some("override"), &flow);
+        assert!(formatted.contains("override"));
+        assert!(formatted.contains("CLI flag --tenant"));
+    }
+
+    #[test]
+    fn dry_run_tenant_fallback_source() {
+        let flow = flow_with_tenant(None);
+        let formatted = format_dry_run_tenant(None, &flow);
+        assert!(formatted.contains("default"));
+        assert!(formatted.contains("fallback"));
     }
 }


### PR DESCRIPTION
## Summary

\`fleet deploy --dry-run\` に 「テナント:」 1 行を追加。 \`--tenant <slug>\` flag or fleet.kdl \`tenant "<slug>"\` block の解決結果 + source label を可視化。

## 動機

PR #172 で tenant block を導入し deploy 時の tenant_slug を kdl-first 解決にしたが、 dry-run path は早期 return していて 「kdl block が読まれて期待通りの tenant に向くか」 を deploy 前に検証する手段が無かった。 実 deploy で初めて分かるのは fail-late。

## 出力例

\`\`\`
[dry-run] ステージ 'live' のデプロイ計画:

  テナント: hq (fleet.kdl tenant block)

  ネットワーク: fleetstage-live (作成予定)
\`\`\`

source label の 3 種:
- \`CLI flag --tenant\`              — \`--tenant <slug>\` 経由
- \`fleet.kdl tenant block\`         — kdl 内の \`tenant "<slug>"\` block
- \`fallback (creds 未確認 or default)\` — 上 2 つが無い (実 deploy で CP creds → "default" の順で確定するため、 dry-run では確定しない旨を明示)

## 構成

- \`print_dry_run_plan\` に \`tenant_override: Option<&str>\` 引数追加、 handle 側で \`--tenant\` flag を pass-through
- 新規 \`format_dry_run_tenant\` 純関数 — slug 解決 + source label を 1 行整形
- test 3 件追加

CP creds は dry-run で呼ばない (= 接続なし) 設計を維持。 dry-run はあくまで 「kdl + CLI flag だけで決まる範囲」 の可視化に留め、 副作用ゼロ。

## Test plan

- [x] fleetflow CLI bin: **9 passed** (既存 6 + 新規 3)
- [ ] CI で workspace 全 test 通過
- [ ] local install 後 \`fleet deploy live --dry-run\` を fleetstage repo で実行し \`テナント: hq (fleet.kdl tenant block)\` 表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)