### PR TITLE
feat(controlplane): Stage に soft-delete (deleted_at) 追加 — tenant_user / project / server と対称

### DIFF
--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -361,7 +361,7 @@ impl Database {
     pub async fn list_stages_by_project(&self, project_id: &RecordId) -> Result<Vec<Stage>> {
         let mut result = self
             .db
-            .query("SELECT * FROM stage WHERE project = $project_id ORDER BY slug")
+            .query("SELECT * FROM stage WHERE project = $project_id AND deleted_at IS NONE ORDER BY slug")
             .bind(("project_id", project_id.clone()))
             .await
             .context("ステージ一覧取得失敗")?;
@@ -377,7 +377,7 @@ impl Database {
         let mut result = self
             .db
             .query(
-                "SELECT id, slug, description, project.slug AS project_slug, project.name AS project_name, project.tenant.slug AS tenant_slug FROM stage WHERE project.tenant.slug = $tenant_slug ORDER BY project_slug, slug",
+                "SELECT id, slug, description, project.slug AS project_slug, project.name AS project_name, project.tenant.slug AS tenant_slug FROM stage WHERE project.tenant.slug = $tenant_slug AND deleted_at IS NONE ORDER BY project_slug, slug",
             )
             .bind(("tenant_slug", tenant_slug.to_string()))
             .await
@@ -395,7 +395,7 @@ impl Database {
         let mut result = self
             .db
             .query(
-                "SELECT id, slug, description, project.slug AS project_slug, project.name AS project_name, project.tenant.slug AS tenant_slug FROM stage WHERE slug = $stage_slug AND project.tenant.slug = $tenant_slug ORDER BY project_slug",
+                "SELECT id, slug, description, project.slug AS project_slug, project.name AS project_name, project.tenant.slug AS tenant_slug FROM stage WHERE slug = $stage_slug AND project.tenant.slug = $tenant_slug AND deleted_at IS NONE ORDER BY project_slug",
             )
             .bind(("tenant_slug", tenant_slug.to_string()))
             .bind(("stage_slug", stage_slug.to_string()))
@@ -424,7 +424,7 @@ impl Database {
                     (SELECT status, created_at FROM deployment WHERE project = $parent.project AND stage = $parent.slug ORDER BY created_at DESC LIMIT 1)[0].created_at AS last_deploy_at,
                     (SELECT count() FROM alert WHERE server_slug = $parent.server.slug AND tenant = $parent.project.tenant AND resolved = false GROUP ALL)[0].count AS alert_count
                 FROM stage
-                WHERE project.tenant.slug = $tenant_slug
+                WHERE project.tenant.slug = $tenant_slug AND deleted_at IS NONE
                 ORDER BY project_slug, slug
                 "#,
             )
@@ -460,7 +460,7 @@ impl Database {
     ) -> Result<Option<Stage>> {
         let mut result = self
             .db
-            .query("SELECT * FROM stage WHERE project = $project AND slug = $slug LIMIT 1")
+            .query("SELECT * FROM stage WHERE project = $project AND slug = $slug AND deleted_at IS NONE LIMIT 1")
             .bind(("project", project_id.clone()))
             .bind(("slug", stage_slug.to_string()))
             .await
@@ -534,6 +534,7 @@ impl Database {
                 server: Some(req.server_id.clone()),
                 created_at: None,
                 updated_at: None,
+                deleted_at: None,
             })
             .await?;
         let stage_id = stage
@@ -2130,6 +2131,7 @@ mod tests {
             server: server.id.clone(),
             created_at: None,
             updated_at: None,
+            deleted_at: None,
         })
         .await
         .unwrap();
@@ -2143,6 +2145,7 @@ mod tests {
             server: None,
             created_at: None,
             updated_at: None,
+            deleted_at: None,
         })
         .await
         .unwrap();

--- a/crates/fleetflow-controlplane/src/handlers/stage.rs
+++ b/crates/fleetflow-controlplane/src/handlers/stage.rs
@@ -33,6 +33,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 server: None,
                                 created_at: None,
                                 updated_at: None,
+                                deleted_at: None,
                             };
 
                             match state.db.create_stage(&stage).await {

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -245,6 +245,10 @@ pub struct Stage {
     pub server: Option<RecordId>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
+    /// Soft-delete tombstone (None = active)。 物理削除は禁止 (memory
+    /// `feedback_no_data_deletion.md` 準拠、 tenant_user / project / server と
+    /// 同 pattern で stage にも soft-delete を提供する)。
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 /// Stage with project info for cross-project queries


### PR DESCRIPTION
## Summary

`Stage` struct + 関連 query に soft-delete (`deleted_at`) を追加。 fleetstage backstage の Moody Blues review #2 (score 85) で **「Stage だけ deleted_at が無い divergence」** として検出された一貫性違反を解消。

## 動機

memory \`feedback_no_data_deletion.md\` の 「物理削除絶対禁止、 soft-delete のみ」 原則に対し、 fleetflow の既存 table:

| table | deleted_at field | logical delete API |
|---|---|---|
| TenantUser | ✅ あり | ✅ \`UPDATE ... SET deleted_at = time::now()\` |
| Project | ✅ あり | ✅ \`delete_project\` |
| Server | ✅ あり | ✅ logical delete |
| **Stage** | ❌ **なし** | ❌ なし |

Stage だけ抜けてた = 後付けで追加された table の見落とし。 fleetstage backstage が \`WHERE deleted_at IS NONE\` で filter しようとしたら field が存在せず、 schema 不整合に。

## 変更

- \`model.rs\`: \`Stage.deleted_at: Option<DateTime<Utc>>\` 追加 (additive change)
- \`db.rs\` の全 Stage SELECT query に \`WHERE deleted_at IS NONE\` filter 追加:
  - \`list_stages_by_project\`
  - \`list_all_stages_by_tenant\` (1st view)
  - \`list_stages_across_projects\` (cross-project 検索)
  - \`list_stage_overviews\` (dashboard 1st view)
  - \`find_stage_by_project_and_slug\` (adopt_stage 用)
- Stage literal 構築箇所に \`deleted_at: None\` 初期化追加 (handlers / tests / db internal)

## Test plan

- [x] \`cargo build -p fleetflow-controlplane\`: PASS
- [x] \`cargo test -p fleetflow-controlplane --lib\`: 46 passed (0 regression)
- [ ] CI で workspace 全 test 通過
- [ ] downstream: fleetstage の \`crates/fleetstage-backstage/src/main.rs\` で stage.deleted_at が正しく filter される確認 (PR merge 後 fleetstage 側で rev bump → integration verify)

## Downstream impact

- fleetstage backstage は既に SCHEMAFULL DDL で stage.deleted_at を定義済 (\`BOOTSTRAP_TEST_DATA=1\` dev path)。 この PR merge 後 prod CP DB の Stage record が deleted_at field を持つようになり、 backstage query が正しく filter される
- 既存 prod Stage record (deleted_at 未設定) は missing field = NONE 扱いで \`WHERE deleted_at IS NONE\` を pass、 後方互換性あり
- 物理 delete API は **追加しない** (soft-delete only)、 必要時は \`UPDATE stage SET deleted_at = time::now()\` を別 PR で

🤖 Generated with [Claude Code](https://claude.com/claude-code)