### PR TITLE
fix(controlplane,fleet-agent): FSC-34 — deploy.execute が flow.stages の server 宣言を honor して agent に routing する

### DIFF
--- a/crates/fleet-agent/Cargo.toml
+++ b/crates/fleet-agent/Cargo.toml
@@ -40,6 +40,10 @@ bollard.workspace = true
 # Build Tier
 fleetflow-build.workspace = true
 
+# kdl-based deploy (DeployEngine + DeployRequest)
+# CP の deploy.execute が server 宣言を読んで agent にリレーする path で必要 (FSC-34)
+fleetflow-container.workspace = true
+
 # CLI
 clap.workspace = true
 

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -121,6 +121,11 @@ async fn command_loop(
             "deploy" => {
                 handle_deploy(&channel, msg.id, &payload, deploy_base).await?;
             }
+            "deploy.execute_kdl" => {
+                // FSC-34: CP から flow.stages[stage].servers で routing された kdl-based deploy
+                // (= bollard + DeployEngine 経由、 既存 docker-compose path とは別)
+                handle_deploy_kdl(&channel, msg.id, &payload).await?;
+            }
             "restart" => {
                 let service = payload["service"].as_str().unwrap_or("");
                 let result = deploy::restart_service(service).await;
@@ -236,6 +241,98 @@ async fn handle_deploy(
     // チャネル送信エラーのみ伝播（ネットワーク断）
     channel
         .send_response(request_id, "deploy", &response)
+        .await?;
+
+    Ok(())
+}
+
+/// FSC-34: kdl-based deploy を local docker daemon で実行する handler。
+///
+/// CP の `deploy.execute` handler が `flow.stages[stage].servers` を resolve して
+/// 該当 server slug の agent (= 自分) にこの method で routing する。 agent は
+/// local docker daemon (= worker の dockerd) に bollard で接続し、 DeployEngine で
+/// container を作成・起動する。
+///
+/// 既存 `deploy` method (= docker-compose 経由) とは **別系統**:
+/// - `deploy`            : payload に compose_path を渡す、 docker-compose CLI spawn
+/// - `deploy.execute_kdl`: payload に DeployRequest (Flow + stage_name + flags)、 bollard 直叩き
+///
+/// log streaming は将来課題 — 現状 deploy 完了まで block して結果を 1 response で返す。
+/// CP 側 timeout を deploy の最大想定時間 (image pull 込み 10 分) に合わせること。
+async fn handle_deploy_kdl(
+    channel: &UnisonChannel,
+    request_id: u64,
+    payload: &serde_json::Value,
+) -> Result<()> {
+    use fleetflow_container::{DeployEngine, DeployRequest};
+
+    // payload を DeployRequest に deserialize
+    let deploy_request: DeployRequest = match serde_json::from_value(payload.clone()) {
+        Ok(r) => r,
+        Err(e) => {
+            channel
+                .send_response(
+                    request_id,
+                    "deploy.execute_kdl",
+                    &json!({
+                        "status": "failed",
+                        "error": format!("invalid DeployRequest: {}", e),
+                    }),
+                )
+                .await?;
+            return Ok(());
+        }
+    };
+
+    // local docker daemon (= worker の dockerd) に bollard 接続
+    let docker = match bollard::Docker::connect_with_local_defaults() {
+        Ok(d) => d,
+        Err(e) => {
+            channel
+                .send_response(
+                    request_id,
+                    "deploy.execute_kdl",
+                    &json!({
+                        "status": "failed",
+                        "error": format!("Docker 接続失敗: {}", e),
+                    }),
+                )
+                .await?;
+            return Ok(());
+        }
+    };
+
+    let engine = DeployEngine::new(docker);
+    let log_buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let log_buffer_clone = log_buffer.clone();
+
+    let result = engine
+        .execute(&deploy_request, move |event| {
+            // event は Debug で文字列化、 後で 1 response として CP に返す
+            log_buffer_clone
+                .lock()
+                .unwrap()
+                .push(format!("{:?}", event));
+        })
+        .await;
+
+    let response = match result {
+        Ok(r) => {
+            let combined = log_buffer.lock().unwrap().join("\n");
+            json!({
+                "status": "success",
+                "log": combined + "\n" + &r.log.join("\n"),
+                "services_deployed": r.services_deployed,
+            })
+        }
+        Err(e) => json!({
+            "status": "failed",
+            "error": e.to_string(),
+        }),
+    };
+
+    channel
+        .send_response(request_id, "deploy.execute_kdl", &response)
         .await?;
 
     Ok(())

--- a/crates/fleetflow-controlplane/src/agent_registry.rs
+++ b/crates/fleetflow-controlplane/src/agent_registry.rs
@@ -79,6 +79,28 @@ impl AgentRegistry {
         method: &str,
         payload: Value,
     ) -> Result<Value, String> {
+        self.send_command_with_timeout(
+            server_slug,
+            method,
+            payload,
+            std::time::Duration::from_secs(60),
+        )
+        .await
+    }
+
+    /// Agent にコマンドを送信し、 timeout を caller で指定する版。
+    ///
+    /// 用途例:
+    /// - `deploy.execute_kdl`: image pull 込み 10 分前後 → 600s
+    /// - `build.execute`: 大きな repo の docker build → 1800s
+    /// - `restart` / `status`: 数秒 → 60s で十分
+    pub async fn send_command_with_timeout(
+        &self,
+        server_slug: &str,
+        method: &str,
+        payload: Value,
+        timeout: std::time::Duration,
+    ) -> Result<Value, String> {
         // ロックを最小限に保持: tx を clone して即解放
         let tx = {
             let agents = self.agents.lock().await;
@@ -99,10 +121,15 @@ impl AgentRegistry {
         .await
         .map_err(|_| format!("Agent '{}' へのコマンド送信失敗", server_slug))?;
 
-        // Agent からの応答を待つ（タイムアウト 60 秒）
-        tokio::time::timeout(std::time::Duration::from_secs(60), response_rx)
+        // Agent からの応答を待つ
+        tokio::time::timeout(timeout, response_rx)
             .await
-            .map_err(|_| format!("Agent '{}' からの応答タイムアウト", server_slug))?
+            .map_err(|_| {
+                format!(
+                    "Agent '{}' からの応答タイムアウト ({:?})",
+                    server_slug, timeout
+                )
+            })?
             .map_err(|_| format!("Agent '{}' の応答チャネルがドロップ", server_slug))
     }
 

--- a/crates/fleetflow-controlplane/src/handlers/deploy.rs
+++ b/crates/fleetflow-controlplane/src/handlers/deploy.rs
@@ -383,13 +383,27 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 }
                             };
 
+                            // FSC-34: flow.stages[stage_name].servers から target server を resolve。
+                            // - 0 件 → CP local docker で実行 (= 旧挙動、 backwards compat)
+                            // - 1 件以上 → 該当 server slug の fleet-agent に RPC routing
+                            //   (現状は first server のみ honor、 multi-server fan-out は将来課題)
+                            let target_server_slug: Option<String> = deploy_request
+                                .flow
+                                .stages
+                                .get(&deploy_request.stage_name)
+                                .and_then(|s| s.servers.first().cloned());
+
+                            let recorded_server_slug = target_server_slug
+                                .clone()
+                                .unwrap_or_else(|| "local".to_string());
+
                             // Deployment レコード作成 (status: "running")
                             let deployment = Deployment {
                                 id: None,
                                 tenant: tenant_id,
                                 project: project_id,
                                 stage: deploy_request.stage_name.clone(),
-                                server_slug: "local".into(),
+                                server_slug: recorded_server_slug.clone(),
                                 status: "running".into(),
                                 command: "deploy.execute".into(),
                                 log: None,
@@ -414,41 +428,82 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                     }
                                 };
 
-                            // Docker 接続 → DeployEngine 実行
-                            let docker = match bollard::Docker::connect_with_local_defaults() {
-                                Ok(d) => d,
-                                Err(e) => {
-                                    error!(error = %e, "Docker 接続失敗");
-                                    channel
-                                        .send_response(
-                                            msg.id,
-                                            "execute",
-                                            &json!({ "error": format!("Docker connection failed: {}", e) }),
-                                        )
-                                        .await?;
-                                    continue;
+                            // ─── deploy 実行: CP local OR agent routing ───
+                            let (status, log_str) = if let Some(server_slug) = &target_server_slug {
+                                // FSC-34: agent 経由 routing
+                                info!(
+                                    server = %server_slug,
+                                    project = project_slug,
+                                    stage = deploy_request.stage_name.as_str(),
+                                    "deploy.execute → agent routing"
+                                );
+
+                                match serde_json::to_value(&deploy_request) {
+                                    Ok(payload_value) => {
+                                        let result = state
+                                            .agent_registry
+                                            .send_command_with_timeout(
+                                                server_slug,
+                                                "deploy.execute_kdl",
+                                                payload_value,
+                                                std::time::Duration::from_secs(600),
+                                            )
+                                            .await;
+
+                                        match result {
+                                            Ok(resp) => {
+                                                let s = resp["status"].as_str().unwrap_or("unknown").to_string();
+                                                let log = resp["log"].as_str()
+                                                    .or_else(|| resp["error"].as_str())
+                                                    .unwrap_or("(no log)")
+                                                    .to_string();
+                                                (s, log)
+                                            }
+                                            Err(e) => ("failed".to_string(), format!("agent routing error: {}", e)),
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!(error = %e, "DeployRequest serialize 失敗");
+                                        ("failed".to_string(), format!("DeployRequest serialize 失敗: {}", e))
+                                    }
                                 }
-                            };
+                            } else {
+                                // 旧挙動: CP local docker daemon で直接実行
+                                let docker = match bollard::Docker::connect_with_local_defaults() {
+                                    Ok(d) => d,
+                                    Err(e) => {
+                                        error!(error = %e, "Docker 接続失敗");
+                                        channel
+                                            .send_response(
+                                                msg.id,
+                                                "execute",
+                                                &json!({ "error": format!("Docker connection failed: {}", e) }),
+                                            )
+                                            .await?;
+                                        continue;
+                                    }
+                                };
 
-                            let engine = DeployEngine::new(docker);
-                            let logs = Arc::new(Mutex::new(Vec::<String>::new()));
-                            let logs_clone = logs.clone();
+                                let engine = DeployEngine::new(docker);
+                                let logs = Arc::new(Mutex::new(Vec::<String>::new()));
+                                let logs_clone = logs.clone();
 
-                            let result = engine
-                                .execute(&deploy_request, move |event| {
-                                    logs_clone
-                                        .lock()
-                                        .unwrap()
-                                        .push(format!("{:?}", event));
-                                })
-                                .await;
+                                let result = engine
+                                    .execute(&deploy_request, move |event| {
+                                        logs_clone
+                                            .lock()
+                                            .unwrap()
+                                            .push(format!("{:?}", event));
+                                    })
+                                    .await;
 
-                            let (status, log_str) = match &result {
-                                Ok(r) => {
-                                    let combined_log = logs.lock().unwrap().join("\n");
-                                    ("success".to_string(), combined_log + "\n" + &r.log.join("\n"))
+                                match &result {
+                                    Ok(r) => {
+                                        let combined_log = logs.lock().unwrap().join("\n");
+                                        ("success".to_string(), combined_log + "\n" + &r.log.join("\n"))
+                                    }
+                                    Err(e) => ("failed".to_string(), e.to_string()),
                                 }
-                                Err(e) => ("failed".to_string(), e.to_string()),
                             };
 
                             // Deployment レコード更新


### PR DESCRIPTION
## Summary

`fleet.kdl` の `stage "live" { server "fleet-worker-01" }` 宣言を **CP の deploy.execute handler が無視** して、 deploy が **CP local docker (= fleetflowd CP daemon の local dockerd)** に着地する bug を fix。 既存の `AgentRegistry` infra を流用して fleet-agent に RPC routing する path を追加。

## 動機

fleetstage backstage-api 初 prod deploy (2026-05-06) で発覚:

- \`fleet.kdl\`:
  \`\`\`kdl
  stage "live" {
      server "fleet-worker-01"
      service "fleetstage-backstage-api"
  }
  \`\`\`
- 期待: fleet-worker-01 (163.43.117.17) に container が起動
- 実際: cp.fleetstage.cloud (163.43.108.56) に起動 → DNS が fleet-worker-01 向きなので **container と DNS が divergence**

fleet-agent ログには deploy event 一切残らず、 deploy 経路が CP-local-only に固定化されていた。 影響範囲: fleetstage 全 deploy + 将来の anycreative tenant 配下 product 移行 plan (gfp / creo-memories 等)。

linked: [FSC-34](https://linear.app/chronista/issue/FSC-34)、 fleetstage memory \`project_fleet_deploy_topology_drift.md\`

## 変更

### \`crates/fleetflow-controlplane/src/handlers/deploy.rs\` の \`execute\` method

target server slug の解決ロジック追加:

\`\`\`rust
let target_server_slug: Option<String> = deploy_request
    .flow.stages.get(&deploy_request.stage_name)
    .and_then(|s| s.servers.first().cloned());

let (status, log_str) = if let Some(server_slug) = &target_server_slug {
    // FSC-34: agent 経由 routing
    state.agent_registry.send_command_with_timeout(
        server_slug,
        "deploy.execute_kdl",
        serde_json::to_value(&deploy_request)?,
        Duration::from_secs(600),
    ).await
    // ...
} else {
    // 旧挙動: CP local docker (= servers 宣言なし時の backwards compat)
    let docker = bollard::Docker::connect_with_local_defaults()?;
    DeployEngine::new(docker).execute(&deploy_request, ...).await
};
\`\`\`

\`deployment.server_slug\` も resolve した値を記録 (旧 \`"local"\` hardcode 廃止)。

### \`crates/fleetflow-controlplane/src/agent_registry.rs\`

\`send_command_with_timeout(server_slug, method, payload, timeout)\` を新設。 既存 \`send_command\` は 60s default の thin wrapper に。 deploy のような長時間 RPC を許容。

### \`crates/fleet-agent/src/agent.rs\` + \`Cargo.toml\`

新 method \`deploy.execute_kdl\` の handler 追加:

\`\`\`rust
"deploy.execute_kdl" => {
    handle_deploy_kdl(&channel, msg.id, &payload).await?;
}

async fn handle_deploy_kdl(channel, request_id, payload) {
    let deploy_request: DeployRequest = serde_json::from_value(payload.clone())?;
    let docker = bollard::Docker::connect_with_local_defaults()?;
    let engine = DeployEngine::new(docker);
    let result = engine.execute(&deploy_request, |event| {/* log */}).await;
    channel.send_response(request_id, "deploy.execute_kdl", &response).await
}
\`\`\`

agent crate に \`fleetflow-container\` 依存追加 (DeployEngine 利用、 binary +2-3MB)。

## 既存 \`deploy\` method との関係

| method | 用途 | docker driver |
|---|---|---|
| \`deploy\` (既存) | docker-compose-based、 payload に \`compose_path\` | \`docker compose\` CLI spawn |
| \`deploy.execute_kdl\` (新) | kdl-based、 payload に \`DeployRequest\` (Flow + stage) | \`bollard\` 直 (DeployEngine) |

両 method は完全独立、 既存 compose-based deploy は影響なし。

## Test plan

- [x] \`cargo build -p fleet-agent\`: PASS
- [x] \`cargo build -p fleetflow-controlplane\`: PASS
- [x] \`cargo test -p fleet-agent --lib\`: 23 passed
- [x] \`cargo test -p fleetflow-controlplane --lib\`: 46 passed
- [x] \`cargo test -p fleetflow-container --lib\`: 20 passed
- [ ] CI で workspace 全 test pass
- [ ] integration: fleetstage の \`fleet deploy live\` で fleet-worker-01 に container 着地確認 (PR merge 後 fleetstage 側 rev bump で)

## Backwards compatibility

\`stage.servers\` が空 (= 既存 kdl で server 宣言なし) なら現状通り CP local docker で実行。 既存 deploy 全 無変更。 server 宣言した時点で **新 routing path が opt-in 起動**。

## 制限事項 / 将来課題

- **multi-server fan-out**: 現状 \`servers.first()\` のみ honor、 複数 server 並列 deploy は別 PR
- **log streaming**: agent → CP は最終 1 response で log まとめて返す、 リアルタイムストリーミングは将来
- **timeout 固定 600s**: deploy 規模に応じた動的調整は将来

🤖 Generated with [Claude Code](https://claude.com/claude-code)