### PR TITLE
fix(fleetflowd): FSC-32 — container_name_to_service に docker compose default 命名 fallback

### DIFF
--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -2393,16 +2393,55 @@ pub fn state_from_docker_state(docker_state: &str) -> &'static str {
     }
 }
 
-/// docker container name（例: "gfp-dev-gfp-web"）から service 名を逆引きする。
-/// フォーマット: `{project}-{stage}-{service_slug}` だが service_slug 自体に `-` を含む場合がある。
-/// → project と stage prefix を取り除く。
+/// docker container name から service 名を逆引きする。
+///
+/// 2 段階で照合:
+///
+/// 1. **fleetstage 規約**: `{project}-{stage}-{service_slug}` (例: `gfp-dev-gfp-web` → `gfp-web`)。
+///    `fleet deploy` 経由で起動した container はこの規約に従う。
+/// 2. **docker compose default 規約 fallback** (FSC-32): primary が hit しなかった時、
+///    compose project 名 = `{project}` 前提で:
+///    - hyphen 形式 (compose v2 default): `{project}-{service}-{N}` (例: `creo-memories-surrealdb-1` → `surrealdb`)
+///    - underscore 形式 (compose v1 互換): `{project}_{service}_{N}` (例: `creo-memories_surrealdb_1` → `surrealdb`)
+///
+///    compose default は container 名に stage を含めないため、 stage 衝突は server 分離で回避する前提
+///    (`adopt` 後の Creo Memories 等、 fleetstage 外で起動された fleet を観測する用途)。
 pub fn container_name_to_service<'a>(
     container_name: &'a str,
     project: &str,
     stage: &str,
 ) -> Option<&'a str> {
-    let prefix = format!("{}-{}-", project, stage);
-    container_name.strip_prefix(&prefix)
+    let primary_prefix = format!("{}-{}-", project, stage);
+    if let Some(rest) = container_name.strip_prefix(&primary_prefix) {
+        return Some(rest);
+    }
+    compose_default_to_service(container_name, project)
+}
+
+/// docker compose default 命名 (`{project}{sep}{service}{sep}{N}`、 sep ∈ {'-', '_'}) を service slug に逆引き。
+fn compose_default_to_service<'a>(container_name: &'a str, project: &str) -> Option<&'a str> {
+    for sep in ['-', '_'] {
+        let prefix = format!("{}{}", project, sep);
+        if let Some(rest) = container_name.strip_prefix(&prefix) {
+            if let Some(svc) = strip_replica_suffix(rest, sep) {
+                return Some(svc);
+            }
+        }
+    }
+    None
+}
+
+/// trailing `{sep}{digits}` (compose の replica index) を削って前半 (= service slug) を返す。
+/// digits が空 / 非数値 / sep なしなら None。
+fn strip_replica_suffix<'a>(s: &'a str, sep: char) -> Option<&'a str> {
+    let last_sep = s.rfind(sep)?;
+    let head = &s[..last_sep];
+    let digits = &s[last_sep + 1..];
+    if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()) {
+        Some(head)
+    } else {
+        None
+    }
 }
 
 /// GET /api/v1/stages/{project}/{stage}/status — ステージの実 runtime status
@@ -2695,6 +2734,67 @@ mod tests {
         assert_eq!(
             container_name_to_service("gfp-dev-gfp-estimate-worker", "gfp", "dev"),
             Some("gfp-estimate-worker")
+        );
+    }
+
+    // FSC-32: compose default 規約への fallback (project 名に stage を含まない fleet)
+
+    #[test]
+    fn container_name_to_service_compose_hyphen() {
+        // compose v2 default: {project}-{service}-{N}
+        assert_eq!(
+            container_name_to_service("creo-memories-surrealdb-1", "creo-memories", "prod"),
+            Some("surrealdb")
+        );
+    }
+
+    #[test]
+    fn container_name_to_service_compose_underscore() {
+        // compose v1 互換: {project}_{service}_{N}
+        assert_eq!(
+            container_name_to_service("creo-memories_surrealdb_1", "creo-memories", "prod"),
+            Some("surrealdb")
+        );
+    }
+
+    #[test]
+    fn container_name_to_service_compose_other_project() {
+        // 別 project の container は project mismatch で None
+        assert_eq!(
+            container_name_to_service("other-app-web-1", "creo-memories", "prod"),
+            None
+        );
+    }
+
+    #[test]
+    fn container_name_to_service_compose_no_replica_suffix() {
+        // compose 命名でも replica suffix 無しは reject
+        // (= 通常の `docker run --name foo-bar` 等を service と誤認しない)
+        assert_eq!(
+            container_name_to_service("creo-memories-surrealdb", "creo-memories", "prod"),
+            None
+        );
+    }
+
+    #[test]
+    fn container_name_to_service_compose_hyphen_with_dashed_service() {
+        // service 名自体に `-` を含む compose container も逆引き可
+        assert_eq!(
+            container_name_to_service(
+                "creo-memories-app-server-1",
+                "creo-memories",
+                "prod"
+            ),
+            Some("app-server")
+        );
+    }
+
+    #[test]
+    fn container_name_to_service_compose_multi_digit_replica() {
+        // replica index は 1+ 桁数値
+        assert_eq!(
+            container_name_to_service("creo-memories-surrealdb-12", "creo-memories", "prod"),
+            Some("surrealdb")
         );
     }
 }

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -2422,10 +2422,10 @@ pub fn container_name_to_service<'a>(
 fn compose_default_to_service<'a>(container_name: &'a str, project: &str) -> Option<&'a str> {
     for sep in ['-', '_'] {
         let prefix = format!("{}{}", project, sep);
-        if let Some(rest) = container_name.strip_prefix(&prefix) {
-            if let Some(svc) = strip_replica_suffix(rest, sep) {
-                return Some(svc);
-            }
+        if let Some(rest) = container_name.strip_prefix(&prefix)
+            && let Some(svc) = strip_replica_suffix(rest, sep)
+        {
+            return Some(svc);
         }
     }
     None
@@ -2433,7 +2433,7 @@ fn compose_default_to_service<'a>(container_name: &'a str, project: &str) -> Opt
 
 /// trailing `{sep}{digits}` (compose の replica index) を削って前半 (= service slug) を返す。
 /// digits が空 / 非数値 / sep なしなら None。
-fn strip_replica_suffix<'a>(s: &'a str, sep: char) -> Option<&'a str> {
+fn strip_replica_suffix(s: &str, sep: char) -> Option<&str> {
     let last_sep = s.rfind(sep)?;
     let head = &s[..last_sep];
     let digits = &s[last_sep + 1..];

--- a/crates/fleetflowd/src/web.rs
+++ b/crates/fleetflowd/src/web.rs
@@ -2780,11 +2780,7 @@ mod tests {
     fn container_name_to_service_compose_hyphen_with_dashed_service() {
         // service 名自体に `-` を含む compose container も逆引き可
         assert_eq!(
-            container_name_to_service(
-                "creo-memories-app-server-1",
-                "creo-memories",
-                "prod"
-            ),
+            container_name_to_service("creo-memories-app-server-1", "creo-memories", "prod"),
             Some("app-server")
         );
     }


### PR DESCRIPTION
## Summary

- `/api/v1/stages/{project}/{stage}/status` と MCP `fleet_logs` の **container 逆引き**を docker compose default 命名形式 (`{project}{sep}{service}{sep}{N}`、 sep ∈ `-` / `_`) にも対応させる
- 既存 `{project}-{stage}-{service}` 規約 (`fleet deploy` 経由) は完全維持、 primary lookup が miss した場合のみ compose fallback に進む additive 拡張
- 結果: **adopt された fleet** (= 元々 docker compose で起動されていた fleet を fleetstage CP record に非破壊で取り込んだ場合) も status / logs API で観測可能に

## Why

`fleet cp stage adopt` で Creo Memories prod stage を CP records に登録 (FSC-16/30 Phase B-3 完走、 2026-04-25) したが、 後続の `fleet_status(creo-memories, prod)` が空配列を返す現象が発覚。

原因: docker compose で起動された container 名は `creo-memories-surrealdb-1` / `creo-memories_surrealdb_1` 形式で、 fleetstage の `{project}-{stage}-{service}` 規約に合わない。 status handler は existing prefix で strip しか試さないので、 すべての service が "stopped" 判定される。

これは **Phase 6 (creo-memories 本体の Path A 移行) の blocker** と Linear FSC-32 で issue 化済。 anycreative tenant migration plan の中でも Phase 6 prerequisite として位置付け。

## Design

`container_name_to_service` を 2 段 lookup に refactor:

1. **Primary**: `{project}-{stage}-{service}` (= fleetstage 規約)
2. **Fallback (FSC-32 新設)**:
   - **hyphen 形式** (compose v2 default): `{project}-{service}-{N}`
   - **underscore 形式** (compose v1 互換): `{project}_{service}_{N}`

   compose 命名は stage を含まないため、 stage 衝突は **server 分離** で回避する前提 (= 1 worker = 1 stage、 同 project の 2 stage が同 worker に co-locate しない)。

新設 helper: `compose_default_to_service` + `strip_replica_suffix` (内部のみ、 公開 API は変更なし)。

## Test plan

- [x] 既存 3 test 維持 (`gfp-dev-gfp-web` / `other-prod-svc` / `gfp-dev-gfp-estimate-worker`)
- [x] 新規 unit test 6 件:
  - `compose_hyphen` (`creo-memories-surrealdb-1` → `surrealdb`)
  - `compose_underscore` (`creo-memories_surrealdb_1` → `surrealdb`)
  - `compose_other_project` (project mismatch → None)
  - `compose_no_replica_suffix` (`creo-memories-surrealdb` → None、 docker run 等を service と誤認しない)
  - `compose_hyphen_with_dashed_service` (`creo-memories-app-server-1` → `app-server`、 service 名に `-` 含む)
  - `compose_multi_digit_replica` (`creo-memories-surrealdb-12` → `surrealdb`、 2 桁 replica)
- [x] `cargo test -p fleetflowd container_name_to_service` → 9/9 passed
- [ ] Creo Memories prod stage に対する `fleet cp stage status` 実機 verify (= self-update 後、 別 PR で fleetstage rev bump 後に手動)

## Scope OUT

- A (custom container_name override field on `Service` model) — 必要が確認されたら別 Issue で
- B (Creo 側 compose の `container_name:` 強制書き換え) — 採用しない

## Refs

- Linear: FSC-32 (parent: FSC-30)
- Related: FSC-34 (deploy 着地先 server routing、 PR #175 で fix 済)
- 同軸認識: 「container 命名規約と deploy/observability の整合性」 軸の 2 issue (deploy 側 = #175、 status 側 = 本 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)