### PR TITLE
fix(controlplane): health channel に heartbeat method を追加

### DIFF
--- a/crates/fleetflow-controlplane/src/handlers/health.rs
+++ b/crates/fleetflow-controlplane/src/handlers/health.rs
@@ -57,15 +57,10 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                         "heartbeat" => {
                             // fleet-agent からの定期 heartbeat。 last_heartbeat_at を更新するだけ。
                             // (handlers/agent.rs / handlers/server.rs と同 logic、 health channel 経路にも対応)
-                            let server_slug =
-                                payload["server_slug"].as_str().unwrap_or_default();
+                            let server_slug = payload["server_slug"].as_str().unwrap_or_default();
                             state.db.update_server_heartbeat(server_slug).await.ok();
                             channel
-                                .send_response(
-                                    msg.id,
-                                    "heartbeat",
-                                    &json!({ "status": "ok" }),
-                                )
+                                .send_response(msg.id, "heartbeat", &json!({ "status": "ok" }))
                                 .await?;
                         }
                         method => {

--- a/crates/fleetflow-controlplane/src/handlers/health.rs
+++ b/crates/fleetflow-controlplane/src/handlers/health.rs
@@ -54,6 +54,20 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 }
                             }
                         }
+                        "heartbeat" => {
+                            // fleet-agent からの定期 heartbeat。 last_heartbeat_at を更新するだけ。
+                            // (handlers/agent.rs / handlers/server.rs と同 logic、 health channel 経路にも対応)
+                            let server_slug =
+                                payload["server_slug"].as_str().unwrap_or_default();
+                            state.db.update_server_heartbeat(server_slug).await.ok();
+                            channel
+                                .send_response(
+                                    msg.id,
+                                    "heartbeat",
+                                    &json!({ "status": "ok" }),
+                                )
+                                .await?;
+                        }
                         method => {
                             info!(method, "health: 不明なメソッド");
                             channel


### PR DESCRIPTION
## Summary

- fleet-agent からの定期 heartbeat が health channel 経由で来るのを、 fleetflowd の health handler が reject していた問題を修正
- 30 秒ごとの log noise (`health: 不明なメソッド method=\"heartbeat\"` + `Channel handler error: Channel closed`) を解消
- `handlers/agent.rs:84` / `handlers/server.rs:137` の既存 heartbeat dispatch pattern を踏襲、 quick fix として既存 channel 構造を維持

## Symptom (= 修正前)

cp.fleetstage.cloud (fleetflowd) と fleet-worker-01 (fleet-agent) の log で 30 秒ごと:

\`\`\`
# fleetflowd
INFO fleetflow_controlplane::handlers::health: health: 不明なメソッド method=\"heartbeat\"
ERROR unison::network::quic: Channel handler error for 'health': Protocol error: Channel closed

# fleet-agent
INFO unison::network::quic: Stream N closed for method '__channel:health'
\`\`\`

## Root cause

\`crates/fleet-agent/src/heartbeat.rs:24\` で:

\`\`\`rust
let channel = client.open_channel(\"health\").await?;
let _: serde_json::Value = channel
    .request(
        \"heartbeat\",
        &json!({ \"server_slug\": ..., \"agent_version\": ... }),
    )
    .await?;
\`\`\`

= **health channel** に **heartbeat method** を request。 しかし \`crates/fleetflow-controlplane/src/handlers/health.rs\` の dispatch は:

\`\`\`rust
match msg.method.as_str() {
    \"overview\" => { ... }
    method => {
        info!(method, \"health: 不明なメソッド\");
        // unknown response
    }
}
\`\`\`

= \`overview\` のみ knows、 \`heartbeat\` は wildcard arm に流れて unknown method response。

## Fix

\`handlers/health.rs\` に \`\"heartbeat\"\` arm 追加。 既存の \`handlers/agent.rs:84-90\` / \`handlers/server.rs:137-149\` の pattern を踏襲:

\`\`\`rust
\"heartbeat\" => {
    let server_slug = payload[\"server_slug\"].as_str().unwrap_or_default();
    state.db.update_server_heartbeat(server_slug).await.ok();
    channel
        .send_response(msg.id, \"heartbeat\", &json!({ \"status\": \"ok\" }))
        .await?;
}
\`\`\`

\`+14 lines\` で 1 file 変更のみ、 minimal scope。

## Note: scope 外 (future refactor)

heartbeat method は **agent / server / health の 3 channel で重複 dispatch** 状態:

| channel | location | logic |
| -- | -- | -- |
| agent | \`handlers/agent.rs:84-90\` | update_server_heartbeat |
| server | \`handlers/server.rs:137-149\` | update_server_heartbeat |
| health | \`handlers/health.rs\` (本 PR) | update_server_heartbeat |

= 「heartbeat はどの channel が責務か」 が design 上曖昧化、 scattered な実装の untrimmed end。 long-term は **agent channel への統合 refactor** (= fleet-agent 側で \`open_channel(\"agent\")\` に変更、 health channel から heartbeat handler 撤去) が望ましい。

ただし refactor は (1) fleet-agent 改修 + redeploy 必要、 (2) channel 単一責務化の design discussion が混在 → **quick fix を先行、 refactor は別 issue**。

## Test plan

- [ ] cargo build -p fleetflow-controlplane が通る (= 確認済)
- [ ] cargo clippy -p fleetflow-controlplane が clean (= 確認済)
- [ ] merge → fleetstage rev bump → fleetflowd self-update 後、 cp.fleetstage.cloud の journalctl で:
  - [ ] \`不明なメソッド method=\"heartbeat\"\` の出現が止まる
  - [ ] \`Channel handler error for 'health': Channel closed\` が止まる
  - [ ] fleet-agent 側 \`Stream N closed for method '__channel:health'\` が止まる
  - [ ] DB の \`server.last_heartbeat_at\` が 30 秒間隔で更新される

## Context

- fleetstage prod deploy (2026-05-06、 wake_04) 後の fleetflowd self-update で発覚
- fleetstage memory: \`feedback_aggressive_update_window.md\` (= 1ヶ月ガンガン更新窓内、 break OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)