### PR TITLE
chore(deps): migrate unison/unison-kdl → club-unison v0.10 + club-kdl v0.5 (crates.io 公開対応)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,20 @@ jobs:
       - name: mise のセットアップ
         run: mise install
 
+      # macOS GH runner では `~/.cargo/bin/rustup` が `rustup-init` (= installer 本体)
+      # を指していて `rustup component add` が unrecognized argument で失敗する
+      # (2026-05-06 頃の runner image 更新で全 PR が同症状)。 公式 rustup-init script
+      # を non-interactive で実行して proper rustup を上書き install、 component subcommand
+      # を使えるようにする。 --default-toolchain none で mise 管理 toolchain と重複回避、
+      # --no-modify-path で PATH 改変 skip、 --profile minimal で余計な component を持たない。
+      # Linux runner は元々 proper rustup なのでこの step は skip。
+      - name: Rust toolchain proper install (macOS workaround)
+        if: matrix.os == 'macos-latest'
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+            sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
+          rustup --version
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Rustツールのインストール

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,9 @@ jobs:
           version: "27.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      # rust version は repo 全体で 1.95 に統一 (.mise.toml / Cargo.toml rust-version と一致)。
+      # coverage job だけ mise でなく dtolnay action 経由なので、 ここも 1.95 pin にする。
+      - uses: dtolnay/rust-toolchain@1.95
         with:
           components: llvm-tools-preview
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ members = [
 [workspace.package]
 version = "0.14.2"
 edition = "2024"
+# rust-version は mise の `[tools].rust` (.mise.toml) と一致させる (SSOT 統一)。
+# 1.95: club-unison v0.10 / constant_time_eq@0.4.3 が rustc 1.95+ を要求するため。
+rust-version = "1.95"
 authors = ["Mito <mito@chronista.club>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/chronista-club/fleetflow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,13 @@ aes-gcm = "0.10"
 
 # KDL parser
 kdl = "6"
-unison-kdl = { git = "https://github.com/chronista-club/unison-kdl", rev = "a5a37ce" }
-unison = { git = "https://github.com/chronista-club/unison", rev = "6a37611" }
+# crates.io 公開命名規則 (club- prefix) — 2026-05-15 移行、 git dep → crates.io dep
+# 旧名 `unison` は RobertWHurst/unison (2018-) と衝突、 旧名 `unison-kdl` も同様に
+# 衝突回避で club- prefix を採用 (chronista-club ecosystem 標準)。
+# v0.10: builder API (v0.8) + buffa pivot (v0.9) + datagram channel (v0.10) を取り込み。
+# fleetflow は higher-level ProtocolClient/ProtocolServer 利用なので additive 互換。
+club-kdl = "0.5"
+club-unison = "0.10"
 
 # Template engine
 tera = "1"

--- a/crates/fleet-agent/Cargo.toml
+++ b/crates/fleet-agent/Cargo.toml
@@ -31,7 +31,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Unison Protocol (QUIC)
-unison.workspace = true
+club-unison.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 # Docker API

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -4,11 +4,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::client::ProtocolClient;
 use serde_json::json;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
-use unison::network::channel::UnisonChannel;
-use unison::network::client::ProtocolClient;
 
 use crate::deploy;
 use crate::heartbeat;

--- a/crates/fleet-agent/src/heartbeat.rs
+++ b/crates/fleet-agent/src/heartbeat.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
+use club_unison::network::client::ProtocolClient;
 use serde_json::json;
 use tracing::{debug, warn};
-use unison::network::client::ProtocolClient;
 
 /// ハートビート送信ループ
 pub async fn run_loop(client: &Arc<ProtocolClient>, server_slug: &str, interval_secs: u64) {

--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -6,9 +6,9 @@ use std::time::{Duration, Instant};
 
 use bollard::Docker;
 use bollard::query_parameters::{InspectContainerOptions, ListContainersOptions};
+use club_unison::network::client::ProtocolClient;
 use serde_json::json;
 use tracing::{debug, error, info, warn};
-use unison::network::client::ProtocolClient;
 
 /// モニター設定
 #[derive(Debug, Clone)]

--- a/crates/fleetflow-controlplane/Cargo.toml
+++ b/crates/fleetflow-controlplane/Cargo.toml
@@ -18,7 +18,7 @@ fleetflow-cloud-cloudflare.workspace = true
 fleetflow-cloud-aws = { workspace = true, optional = true }
 
 # Communication
-unison.workspace = true
+club-unison.workspace = true
 
 # Docker
 bollard.workspace = true

--- a/crates/fleetflow-controlplane/src/handlers/agent.rs
+++ b/crates/fleetflow-controlplane/src/handlers/agent.rs
@@ -9,10 +9,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::{Value, json};
 use tracing::{error, info, warn};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::agent_registry::AgentCommand;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/build.rs
+++ b/crates/fleetflow-controlplane/src/handlers/build.rs
@@ -7,10 +7,10 @@
 
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::{BuildJob, BuildSource, BuildTarget, build_job_kind, build_job_state};
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/container.rs
+++ b/crates/fleetflow-controlplane/src/handlers/container.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::info;
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/cost.rs
+++ b/crates/fleetflow-controlplane/src/handlers/cost.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::CostEntry;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/deploy.rs
+++ b/crates/fleetflow-controlplane/src/handlers/deploy.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use fleetflow_container::{DeployEngine, DeployRequest};
 use serde_json::json;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::Deployment;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/dns.rs
+++ b/crates/fleetflow-controlplane/src/handlers/dns.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::DnsRecord;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/health.rs
+++ b/crates/fleetflow-controlplane/src/handlers/health.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/mod.rs
+++ b/crates/fleetflow-controlplane/src/handlers/mod.rs
@@ -12,8 +12,8 @@ pub mod stage;
 pub mod tenant;
 pub mod volume;
 
+use club_unison::network::server::ProtocolServer;
 use std::sync::Arc;
-use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/project.rs
+++ b/crates/fleetflow-controlplane/src/handlers/project.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::Project;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use chrono::Utc;
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::{Alert, Server, ServerStatusUpdate};
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/service.rs
+++ b/crates/fleetflow-controlplane/src/handlers/service.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/stage.rs
+++ b/crates/fleetflow-controlplane/src/handlers/stage.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::{AdoptServiceSpec, AdoptStageRequest, Stage};
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/tenant.rs
+++ b/crates/fleetflow-controlplane/src/handlers/tenant.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::Tenant;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/volume.rs
+++ b/crates/fleetflow-controlplane/src/handlers/volume.rs
@@ -7,10 +7,10 @@
 
 use std::sync::Arc;
 
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 
 use crate::model::volume_tier;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/server.rs
+++ b/crates/fleetflow-controlplane/src/server.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use club_unison::network::server::{ProtocolServer, ServerHandle};
 use tracing::info;
-use unison::network::server::{ProtocolServer, ServerHandle};
 
 use crate::agent_registry::AgentRegistry;
 use crate::auth::{Auth0Config, Auth0Verifier, AuthProviderKind};

--- a/crates/fleetflow-controlplane/tests/channel_integration.rs
+++ b/crates/fleetflow-controlplane/tests/channel_integration.rs
@@ -5,9 +5,9 @@
 
 use std::sync::Arc;
 
+use club_unison::network::client::ProtocolClient;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
-use unison::network::client::ProtocolClient;
-use unison::network::server::ProtocolServer;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;
 use fleetflow_controlplane::auth::AuthProviderKind;

--- a/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
+++ b/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
@@ -6,9 +6,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use club_unison::network::client::ProtocolClient;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
-use unison::network::client::ProtocolClient;
-use unison::network::server::ProtocolServer;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;
 use fleetflow_controlplane::auth::AuthProviderKind;

--- a/crates/fleetflow-controlplane/tests/server_crud_test.rs
+++ b/crates/fleetflow-controlplane/tests/server_crud_test.rs
@@ -5,9 +5,9 @@
 
 use std::sync::Arc;
 
+use club_unison::network::client::ProtocolClient;
+use club_unison::network::server::ProtocolServer;
 use serde_json::json;
-use unison::network::client::ProtocolClient;
-use unison::network::server::ProtocolServer;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;
 use fleetflow_controlplane::auth::AuthProviderKind;

--- a/crates/fleetflow-core/Cargo.toml
+++ b/crates/fleetflow-core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 kdl.workspace = true
-unison-kdl.workspace = true
+club-kdl.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/fleetflow-core/src/model/port.rs
+++ b/crates/fleetflow-core/src/model/port.rs
@@ -1,9 +1,9 @@
 //! ポート定義
 
-use serde::{Deserialize, Serialize};
-use unison_kdl::{
+use club_kdl::{
     Error as KdlError, FromKdlValue, KdlDeserialize, KdlSerialize, KdlValue, ToKdlValue,
 };
+use serde::{Deserialize, Serialize};
 
 /// ポート定義
 #[derive(Debug, Clone, Serialize, Deserialize, KdlDeserialize, KdlSerialize)]
@@ -49,7 +49,7 @@ impl Protocol {
 
 // KDL変換の実装
 impl<'de> FromKdlValue<'de> for Protocol {
-    fn from_kdl_value(value: &'de KdlValue) -> unison_kdl::Result<Self> {
+    fn from_kdl_value(value: &'de KdlValue) -> club_kdl::Result<Self> {
         value
             .as_string()
             .map(Protocol::parse)

--- a/crates/fleetflow-core/src/model/service.rs
+++ b/crates/fleetflow-core/src/model/service.rs
@@ -2,12 +2,12 @@
 
 use super::port::Port;
 use super::volume::Volume;
+use club_kdl::{
+    Error as KdlError, FromKdlValue, KdlDeserialize, KdlSerialize, KdlValue, ToKdlValue,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use unison_kdl::{
-    Error as KdlError, FromKdlValue, KdlDeserialize, KdlSerialize, KdlValue, ToKdlValue,
-};
 
 /// サービス定義
 ///
@@ -90,7 +90,7 @@ impl ServiceType {
 }
 
 impl<'de> FromKdlValue<'de> for ServiceType {
-    fn from_kdl_value(value: &'de KdlValue) -> unison_kdl::Result<Self> {
+    fn from_kdl_value(value: &'de KdlValue) -> club_kdl::Result<Self> {
         value
             .as_string()
             .and_then(Self::parse)
@@ -178,7 +178,7 @@ impl RestartPolicy {
 
 // KDL変換の実装
 impl<'de> FromKdlValue<'de> for RestartPolicy {
-    fn from_kdl_value(value: &'de KdlValue) -> unison_kdl::Result<Self> {
+    fn from_kdl_value(value: &'de KdlValue) -> club_kdl::Result<Self> {
         value
             .as_string()
             .and_then(Self::parse)

--- a/crates/fleetflow-core/src/model/volume.rs
+++ b/crates/fleetflow-core/src/model/volume.rs
@@ -1,8 +1,8 @@
 //! ボリューム定義
 
+use club_kdl::{KdlDeserialize, KdlSerialize};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use unison_kdl::{KdlDeserialize, KdlSerialize};
 
 /// ボリューム定義
 ///

--- a/crates/fleetflow-core/src/parser/tests.rs
+++ b/crates/fleetflow-core/src/parser/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::model::{Port, Protocol, ServiceType, Volume};
-use unison_kdl::{KdlDeserialize, KdlNodeExt, KdlSerialize};
+use club_kdl::{KdlDeserialize, KdlNodeExt, KdlSerialize};
 
 #[test]
 fn test_parse_static_service() {

--- a/crates/fleetflow-mcp/Cargo.toml
+++ b/crates/fleetflow-mcp/Cargo.toml
@@ -32,7 +32,7 @@ futures-util.workspace = true
 bollard.workspace = true
 
 # CP integration (v2)
-unison.workspace = true
+club-unison.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 dirs = "6"
 chrono.workspace = true

--- a/crates/fleetflow-mcp/src/cp.rs
+++ b/crates/fleetflow-mcp/src/cp.rs
@@ -3,9 +3,9 @@
 //! CLI 側の cp_client と同じロジックだが、MCP crate 内で自己完結するよう簡略版として実装。
 
 use anyhow::{Context, Result};
+use club_unison::network::client::ProtocolClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use unison::network::client::ProtocolClient;
 
 /// Dashboard API のベース URL
 const DASHBOARD_BASE: &str = "http://127.0.0.1:32080";

--- a/crates/fleetflow/Cargo.toml
+++ b/crates/fleetflow/Cargo.toml
@@ -62,7 +62,7 @@ libc = "0.2"
 open = "5"
 
 # Control Plane client
-unison.workspace = true
+club-unison.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [dev-dependencies]

--- a/crates/fleetflow/src/commands/cp_client.rs
+++ b/crates/fleetflow/src/commands/cp_client.rs
@@ -4,9 +4,9 @@
 //! ProtocolClient で CP に接続して channel を開く。
 
 use anyhow::{Context, Result};
+use club_unison::network::client::ProtocolClient;
 use colored::Colorize;
 use serde_json::Value;
-use unison::network::client::ProtocolClient;
 
 use super::auth::Credentials;
 


### PR DESCRIPTION
## Summary

upstream unison が crates.io に公開された **club-unison v0.10 + club-kdl v0.5** への migration。 git dep → crates.io dep、 crate 名は `club-` prefix に統一 (= 既存 OSS `unison` 2018- との衝突回避、 chronista-club ecosystem 標準命名規則)。

本 PR は 3 つの commit を束ねる:

1. **`653bfa1`** — club-unison v0.10 + club-kdl v0.5 migration 本体
2. **`4a6ae56`** — macOS CI fix (rustup-init → proper rustup)
3. **`62097c7`** — rust toolchain を 1.95 に統一

## 1. club-unison v0.10 migration

### Cargo.toml (root + member 5 file)

```diff
-unison-kdl = { git = "https://github.com/chronista-club/unison-kdl", rev = "a5a37ce" }
-unison = { git = "https://github.com/chronista-club/unison", rev = "6a37611" }
+club-kdl = "0.5"
+club-unison = "0.10"
```

member 5 crate で `unison.workspace = true` → `club-unison.workspace = true`、 1 crate で `unison-kdl.workspace = true` → `club-kdl.workspace = true`。

### .rs files (27 file)

`use unison::...` → `use club_unison::...`、 `use unison_kdl::...` → `use club_kdl::...` 一括置換。

### migration scope

- ✅ fleetflow は higher-level `ProtocolClient` / `ProtocolServer` / `UnisonChannel` 利用 → v0.7→v0.10 の API は signature-stable、 additive 互換
- ✅ v0.10 で取り込まれた builder API (v0.8) / buffa pivot (v0.9) / datagram channel (v0.10) は fleetflow 未使用、 lower-level API への migration は不要
- ✅ public API surface 不変 → downstream (fleetstage 等) は本 PR の影響 0

### なぜ急ぐか

`unison-kdl` git repo が `club-kdl` に rename され、 main の `unison-kdl = {git=...}` が dep resolution で解決不能 → **main が build-broken**。 本 PR が main を unbreak する。

## 2. macOS CI fix

macOS GH runner で `~/.cargo/bin/rustup` が `rustup-init` (installer 本体) を指し、 `rustup component add` が unrecognized argument で失敗 (2026-05 頃の runner image 更新で発症)。 公式 rustup-init script を non-interactive 実行して proper rustup を install。 元は別 PR #182 だったが、 broken main 上では #182 単独で ubuntu test が即死する deadlock 構造のため本 PR に cherry-pick で統合 (#182 は superseded で close)。

## 3. rust 1.95 統一

rust version 宣言を 3 経路で 1.95 に揃える: `.mise.toml` `[tools].rust` (既に 1.95) / `Cargo.toml` `[workspace.package].rust-version` (新規追加) / `ci.yml` coverage job の `dtolnay/rust-toolchain` (`@stable` → `@1.95`)。

## upstream fix の取り込み

upstream PR #30 (quic.rs の Channel closed log degrade) が v0.10 release chain で取り込み済。 本 migration + fleetstage cascade + fleetflowd redeploy で `Channel handler error ... Channel closed` (24h 5739 件の log noise) が解消。

## 検証

- `cargo check --workspace` ✅
- `cargo clippy --workspace --all-targets` ✅ warning 0
- `cargo fmt --check` ✅ clean
- `cargo test --workspace` ✅ 0 failed
- CI ✅ 全 job green (macOS / ubuntu fast-tests / security / coverage / claude-review)

## Cascade plan

- [x] **fleetflow**: 本 PR
- [ ] **fleetstage**: Cargo.toml の fleetflow rev bump (Stage 3)
- [ ] **deploy**: fleetflowd (cp.fleetstage.cloud) + fleet-agent (fleet-worker-01) rebuild + redeploy (Stage 4)
- [ ] verify: cp journal で 5739 件の Channel closed ERROR が消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)