### PR TITLE
ci(macos): rustup-init → proper rustup を install して `component add` を可能に

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,20 @@ jobs:
       - name: mise のセットアップ
         run: mise install
 
+      # macOS GH runner では `~/.cargo/bin/rustup` が `rustup-init` (= installer 本体)
+      # を指していて `rustup component add` が unrecognized argument で失敗する
+      # (2026-05-06 頃の runner image 更新で全 PR が同症状)。 公式 rustup-init script
+      # を non-interactive で実行して proper rustup を上書き install、 component subcommand
+      # を使えるようにする。 --default-toolchain none で mise 管理 toolchain と重複回避、
+      # --no-modify-path で PATH 改変 skip、 --profile minimal で余計な component を持たない。
+      # Linux runner は元々 proper rustup なのでこの step は skip。
+      - name: Rust toolchain proper install (macOS workaround)
+        if: matrix.os == 'macos-latest'
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+            sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
+          rustup --version
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Rustツールのインストール


### PR DESCRIPTION
## Symptom

2026-05-06 以降の fleetflow PR で **macOS 高速テストが repo-wide で fail**:

\`\`\`
[setup] \$ rustup component add rustfmt clippy
error: error: unexpected argument 'component' found
Usage: rustup-init[EXE] [OPTIONS]
\`\`\`

## Root cause

macOS GitHub runner image で \`~/.cargo/bin/rustup\` が **\`rustup-init\` (= installer 本体)** を指している。 \`rustup-init\` は \`component\` subcommand を持たないので、 \`.mise.toml\` の \`[tasks.setup]\` で実行される \`rustup component add rustfmt clippy\` が **unrecognized argument** で fail。

mise の rust plugin は rustup-init を用いて toolchain を install するが、 install 後の rustup binary 自体は上書きしないため、 PATH 上の \`rustup\` (= rustup-init) が残る。 Linux runner は proper rustup が pre-installed で無問題。

## Fix

\`fast-tests\` job の \`mise install\` 後 + \`Swatinem/rust-cache\` 前に、 **macOS 限定** で公式 rustup-init script を non-interactive で実行する step を追加。 \`~/.cargo/bin/rustup\` が proper rustup に上書きされ、 後続の \`rustup component add\` が動く。

\`\`\`yaml
- name: Rust toolchain proper install (macOS workaround)
  if: matrix.os == 'macos-latest'
  run: |
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
      sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
    rustup --version
\`\`\`

オプション選択理由:
- \`-y\` non-interactive (CI 必須)
- \`--no-modify-path\` PATH 改変 skip (GH Actions が管理)
- \`--default-toolchain none\` toolchain 重複 install 回避 (mise が rust@1.95 入れてる)
- \`--profile minimal\` rustfmt / clippy は \`mise run setup\` で後入れ

## Scope

- 1 file 変更、 14 lines insert
- **dev-env 不変**: \`.mise.toml\` は touch せず、 CI 局所修正
- \`docker-tests\` job は ubuntu-only で macOS step は no-op (= \`matrix.os\` 不在で \`if\` false)
- 既存 cache 範囲影響なし

## Affected

このまま放置すると **全 PR が macos check で BLOCKED**。 修正後 PR #180 / #181 等の merge 道筋が開く。

## Test plan

- [ ] CI run で \`fast-tests (macos-latest)\` の "Rust toolchain proper install" step が rustup version を print
- [ ] 後続 \`mise run setup\` が \`rustup component add rustfmt clippy\` 成功
- [ ] \`フォーマットチェック\` / \`Clippy\` / \`高速テスト\` まで通過
- [ ] PR #180 / #181 の rerun で macOS green

## Related

- 発端: fleetstage prod の deploy.execute timeout 調査 → fleetflow rev bump cascade で発覚
- 関連 PR: #181 (club-unison v0.7 migration、 macOS で同症状で blocked)
- fleetstage memory: \`mem_1Cb37qLW3Yq1hE7kQmV34a\` (= unison v0.7 migration scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)