### PR TITLE
chore(deps): migrate to club-unison v1.0.0-rc.1 + club-kdl v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,10 +73,9 @@ kdl = "6"
 # crates.io 公開命名規則 (club- prefix) — 2026-05-15 移行、 git dep → crates.io dep
 # 旧名 `unison` は RobertWHurst/unison (2018-) と衝突、 旧名 `unison-kdl` も同様に
 # 衝突回避で club- prefix を採用 (chronista-club ecosystem 標準)。
-# v0.10: builder API (v0.8) + buffa pivot (v0.9) + datagram channel (v0.10) を取り込み。
-# fleetflow は higher-level ProtocolClient/ProtocolServer 利用なので additive 互換。
-club-kdl = "0.5"
-club-unison = "0.10"
+# v1.0.0-rc.1: 1.0 リリース候補。 fleetflow は higher-level ProtocolClient/ProtocolServer 利用。
+club-kdl = "0.8"
+club-unison = "1.0.0-rc.1"
 
 # Template engine
 tera = "1"

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -4,11 +4,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use unison::network::channel::UnisonChannel;
-use unison::network::client::ProtocolClient;
 use serde_json::json;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
+use unison::network::channel::UnisonChannel;
+use unison::network::client::ProtocolClient;
 
 use crate::deploy;
 use crate::heartbeat;

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::client::ProtocolClient;
+use unison::network::channel::UnisonChannel;
+use unison::network::client::ProtocolClient;
 use serde_json::json;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};

--- a/crates/fleet-agent/src/heartbeat.rs
+++ b/crates/fleet-agent/src/heartbeat.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
-use unison::network::client::ProtocolClient;
 use serde_json::json;
 use tracing::{debug, warn};
+use unison::network::client::ProtocolClient;
 
 /// ハートビート送信ループ
 pub async fn run_loop(client: &Arc<ProtocolClient>, server_slug: &str, interval_secs: u64) {

--- a/crates/fleet-agent/src/heartbeat.rs
+++ b/crates/fleet-agent/src/heartbeat.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use club_unison::network::client::ProtocolClient;
+use unison::network::client::ProtocolClient;
 use serde_json::json;
 use tracing::{debug, warn};
 

--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -6,9 +6,9 @@ use std::time::{Duration, Instant};
 
 use bollard::Docker;
 use bollard::query_parameters::{InspectContainerOptions, ListContainersOptions};
-use unison::network::client::ProtocolClient;
 use serde_json::json;
 use tracing::{debug, error, info, warn};
+use unison::network::client::ProtocolClient;
 
 /// モニター設定
 #[derive(Debug, Clone)]

--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use bollard::Docker;
 use bollard::query_parameters::{InspectContainerOptions, ListContainersOptions};
-use club_unison::network::client::ProtocolClient;
+use unison::network::client::ProtocolClient;
 use serde_json::json;
 use tracing::{debug, error, info, warn};
 

--- a/crates/fleetflow-controlplane/src/handlers/agent.rs
+++ b/crates/fleetflow-controlplane/src/handlers/agent.rs
@@ -9,10 +9,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::{Value, json};
 use tracing::{error, info, warn};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::agent_registry::AgentCommand;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/agent.rs
+++ b/crates/fleetflow-controlplane/src/handlers/agent.rs
@@ -9,8 +9,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::{Value, json};
 use tracing::{error, info, warn};
 

--- a/crates/fleetflow-controlplane/src/handlers/build.rs
+++ b/crates/fleetflow-controlplane/src/handlers/build.rs
@@ -7,10 +7,10 @@
 
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::{BuildJob, BuildSource, BuildTarget, build_job_kind, build_job_state};
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/build.rs
+++ b/crates/fleetflow-controlplane/src/handlers/build.rs
@@ -7,8 +7,8 @@
 
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
 

--- a/crates/fleetflow-controlplane/src/handlers/container.rs
+++ b/crates/fleetflow-controlplane/src/handlers/container.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::info;
 

--- a/crates/fleetflow-controlplane/src/handlers/container.rs
+++ b/crates/fleetflow-controlplane/src/handlers/container.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::info;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/cost.rs
+++ b/crates/fleetflow-controlplane/src/handlers/cost.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::CostEntry;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/cost.rs
+++ b/crates/fleetflow-controlplane/src/handlers/cost.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};

--- a/crates/fleetflow-controlplane/src/handlers/deploy.rs
+++ b/crates/fleetflow-controlplane/src/handlers/deploy.rs
@@ -1,8 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use fleetflow_container::{DeployEngine, DeployRequest};
 use serde_json::json;
 use tracing::{error, info};

--- a/crates/fleetflow-controlplane/src/handlers/deploy.rs
+++ b/crates/fleetflow-controlplane/src/handlers/deploy.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use fleetflow_container::{DeployEngine, DeployRequest};
 use serde_json::json;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::Deployment;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/dns.rs
+++ b/crates/fleetflow-controlplane/src/handlers/dns.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::DnsRecord;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/dns.rs
+++ b/crates/fleetflow-controlplane/src/handlers/dns.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};

--- a/crates/fleetflow-controlplane/src/handlers/health.rs
+++ b/crates/fleetflow-controlplane/src/handlers/health.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/health.rs
+++ b/crates/fleetflow-controlplane/src/handlers/health.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
 

--- a/crates/fleetflow-controlplane/src/handlers/mod.rs
+++ b/crates/fleetflow-controlplane/src/handlers/mod.rs
@@ -12,7 +12,7 @@ pub mod stage;
 pub mod tenant;
 pub mod volume;
 
-use club_unison::network::server::ProtocolServer;
+use unison::network::server::ProtocolServer;
 use std::sync::Arc;
 
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/mod.rs
+++ b/crates/fleetflow-controlplane/src/handlers/mod.rs
@@ -12,8 +12,8 @@ pub mod stage;
 pub mod tenant;
 pub mod volume;
 
-use unison::network::server::ProtocolServer;
 use std::sync::Arc;
+use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/project.rs
+++ b/crates/fleetflow-controlplane/src/handlers/project.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::Project;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/project.rs
+++ b/crates/fleetflow-controlplane/src/handlers/project.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
 

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use chrono::Utc;
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
 

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use chrono::Utc;
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::{Alert, Server, ServerStatusUpdate};
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/service.rs
+++ b/crates/fleetflow-controlplane/src/handlers/service.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::server::AppState;
 

--- a/crates/fleetflow-controlplane/src/handlers/service.rs
+++ b/crates/fleetflow-controlplane/src/handlers/service.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};

--- a/crates/fleetflow-controlplane/src/handlers/stage.rs
+++ b/crates/fleetflow-controlplane/src/handlers/stage.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::{AdoptServiceSpec, AdoptStageRequest, Stage};
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/stage.rs
+++ b/crates/fleetflow-controlplane/src/handlers/stage.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use surrealdb::types::RecordId;
 use tracing::{error, info};

--- a/crates/fleetflow-controlplane/src/handlers/tenant.rs
+++ b/crates/fleetflow-controlplane/src/handlers/tenant.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::Tenant;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/tenant.rs
+++ b/crates/fleetflow-controlplane/src/handlers/tenant.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
 

--- a/crates/fleetflow-controlplane/src/handlers/volume.rs
+++ b/crates/fleetflow-controlplane/src/handlers/volume.rs
@@ -7,10 +7,10 @@
 
 use std::sync::Arc;
 
-use unison::network::channel::UnisonChannel;
-use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 
 use crate::model::volume_tier;
 use crate::server::AppState;

--- a/crates/fleetflow-controlplane/src/handlers/volume.rs
+++ b/crates/fleetflow-controlplane/src/handlers/volume.rs
@@ -7,8 +7,8 @@
 
 use std::sync::Arc;
 
-use club_unison::network::channel::UnisonChannel;
-use club_unison::network::server::ProtocolServer;
+use unison::network::channel::UnisonChannel;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 use tracing::{error, info};
 

--- a/crates/fleetflow-controlplane/src/server.rs
+++ b/crates/fleetflow-controlplane/src/server.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use club_unison::network::server::{ProtocolServer, ServerHandle};
+use unison::network::server::{ProtocolServer, ServerHandle};
 use tracing::info;
 
 use crate::agent_registry::AgentRegistry;

--- a/crates/fleetflow-controlplane/src/server.rs
+++ b/crates/fleetflow-controlplane/src/server.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use unison::network::server::{ProtocolServer, ServerHandle};
 use tracing::info;
+use unison::network::server::{ProtocolServer, ServerHandle};
 
 use crate::agent_registry::AgentRegistry;
 use crate::auth::{Auth0Config, Auth0Verifier, AuthProviderKind};

--- a/crates/fleetflow-controlplane/tests/channel_integration.rs
+++ b/crates/fleetflow-controlplane/tests/channel_integration.rs
@@ -5,9 +5,9 @@
 
 use std::sync::Arc;
 
+use serde_json::json;
 use unison::network::client::ProtocolClient;
 use unison::network::server::ProtocolServer;
-use serde_json::json;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;
 use fleetflow_controlplane::auth::AuthProviderKind;

--- a/crates/fleetflow-controlplane/tests/channel_integration.rs
+++ b/crates/fleetflow-controlplane/tests/channel_integration.rs
@@ -5,8 +5,8 @@
 
 use std::sync::Arc;
 
-use club_unison::network::client::ProtocolClient;
-use club_unison::network::server::ProtocolServer;
+use unison::network::client::ProtocolClient;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;

--- a/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
+++ b/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
@@ -6,9 +6,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use serde_json::json;
 use unison::network::client::ProtocolClient;
 use unison::network::server::ProtocolServer;
-use serde_json::json;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;
 use fleetflow_controlplane::auth::AuthProviderKind;

--- a/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
+++ b/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use club_unison::network::client::ProtocolClient;
-use club_unison::network::server::ProtocolServer;
+use unison::network::client::ProtocolClient;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;

--- a/crates/fleetflow-controlplane/tests/server_crud_test.rs
+++ b/crates/fleetflow-controlplane/tests/server_crud_test.rs
@@ -5,9 +5,9 @@
 
 use std::sync::Arc;
 
+use serde_json::json;
 use unison::network::client::ProtocolClient;
 use unison::network::server::ProtocolServer;
-use serde_json::json;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;
 use fleetflow_controlplane::auth::AuthProviderKind;

--- a/crates/fleetflow-controlplane/tests/server_crud_test.rs
+++ b/crates/fleetflow-controlplane/tests/server_crud_test.rs
@@ -5,8 +5,8 @@
 
 use std::sync::Arc;
 
-use club_unison::network::client::ProtocolClient;
-use club_unison::network::server::ProtocolServer;
+use unison::network::client::ProtocolClient;
+use unison::network::server::ProtocolServer;
 use serde_json::json;
 
 use fleetflow_controlplane::agent_registry::AgentRegistry;

--- a/crates/fleetflow-mcp/src/cp.rs
+++ b/crates/fleetflow-mcp/src/cp.rs
@@ -3,9 +3,9 @@
 //! CLI 側の cp_client と同じロジックだが、MCP crate 内で自己完結するよう簡略版として実装。
 
 use anyhow::{Context, Result};
-use unison::network::client::ProtocolClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use unison::network::client::ProtocolClient;
 
 /// Dashboard API のベース URL
 const DASHBOARD_BASE: &str = "http://127.0.0.1:32080";

--- a/crates/fleetflow-mcp/src/cp.rs
+++ b/crates/fleetflow-mcp/src/cp.rs
@@ -3,7 +3,7 @@
 //! CLI 側の cp_client と同じロジックだが、MCP crate 内で自己完結するよう簡略版として実装。
 
 use anyhow::{Context, Result};
-use club_unison::network::client::ProtocolClient;
+use unison::network::client::ProtocolClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/crates/fleetflow/src/commands/cp_client.rs
+++ b/crates/fleetflow/src/commands/cp_client.rs
@@ -4,7 +4,7 @@
 //! ProtocolClient で CP に接続して channel を開く。
 
 use anyhow::{Context, Result};
-use club_unison::network::client::ProtocolClient;
+use unison::network::client::ProtocolClient;
 use colored::Colorize;
 use serde_json::Value;
 

--- a/crates/fleetflow/src/commands/cp_client.rs
+++ b/crates/fleetflow/src/commands/cp_client.rs
@@ -4,9 +4,9 @@
 //! ProtocolClient で CP に接続して channel を開く。
 
 use anyhow::{Context, Result};
-use unison::network::client::ProtocolClient;
 use colored::Colorize;
 use serde_json::Value;
+use unison::network::client::ProtocolClient;
 
 use super::auth::Credentials;
 


### PR DESCRIPTION
## 概要

`kdl` / `unison` を crates.io 最新版へアップデート。

| crate | 変更 |
|-------|------|
| `club-unison` | 0.10 → **1.0.0-rc.1**（1.0 リリース候補） |
| `club-kdl` | 0.5 → **0.8.0** |
| `kdl`（upstream） | 6.5.0（既に最新、変更なし） |

## 破壊的変更への適合

club-unison 1.0.0-rc.1 で **lib 名が `club_unison` → `unison` に変更**された（`[lib] name = "unison"`）。
パッケージ名は `club-unison` のまま、import 名のみ変更。

- src 20 ファイル + tests 3 ファイルの `use club_unison::` を `use unison::` に一括 rename
- モジュール構造（`network::client`、`network::server` 等）は不変
- higher-level な `ProtocolClient` / `ProtocolServer` API も互換

club-kdl 0.8.0 は API 互換でコード変更不要。

## 注意点

club-unison rc.1 は内部で club-kdl 0.5.1 を使うため 0.5/0.8 が共存するが、
unison の club-kdl は schema パース用の内部実装で型の越境が無いため無害。
upstream が club-kdl を bump すれば自然解消。

## 検証

- `cargo build --workspace` ✓
- `cargo test --workspace` ✓（750+ pass / 0 fail）
- `cargo clippy --workspace --all-targets` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)