### PR TITLE
chore(deps): bollard 0.19 → 0.21 — Docker API モデル破壊的変更に適合

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Docker
-bollard = "0.19"
+bollard = "0.21"
 
 # Configuration
 config = "0.13"

--- a/crates/fleetflow-build/src/pusher.rs
+++ b/crates/fleetflow-build/src/pusher.rs
@@ -62,8 +62,14 @@ impl ImagePusher {
         while let Some(result) = stream.next().await {
             match result {
                 Ok(info) => {
-                    if let Some(err) = info.error {
-                        error_message = Some(err);
+                    // bollard 0.21: error: Option<String> → error_detail: Option<ErrorDetail>
+                    if let Some(detail) = &info.error_detail {
+                        error_message = Some(
+                            detail
+                                .message
+                                .clone()
+                                .unwrap_or_else(|| "unknown push error".to_string()),
+                        );
                     } else {
                         self.handle_progress(&info, &mut last_status);
                     }
@@ -126,7 +132,15 @@ impl ImagePusher {
     /// プッシュ進捗を表示
     fn handle_progress(&self, info: &PushImageInfo, last_status: &mut String) {
         if let Some(status) = &info.status {
-            let progress = info.progress.as_deref().unwrap_or("");
+            // bollard 0.21: 整形済み progress 文字列が廃止 → progress_detail(current/total) から再構成
+            let progress = info
+                .progress_detail
+                .as_ref()
+                .and_then(|pd| match (pd.current, pd.total) {
+                    (Some(c), Some(t)) if t > 0 => Some(format!("{c}/{t}")),
+                    _ => None,
+                })
+                .unwrap_or_default();
 
             // 状態に応じた表示
             match status.as_str() {

--- a/crates/fleetflow-container/src/converter.rs
+++ b/crates/fleetflow-container/src/converter.rs
@@ -54,7 +54,8 @@ pub fn service_to_container_config_with_network(
 
     // ポートバインディングの設定
     let mut port_bindings = HashMap::new();
-    let mut exposed_ports: HashMap<String, HashMap<(), ()>> = HashMap::new();
+    // bollard 0.21: exposed_ports は Vec<String>（旧 HashMap<String, HashMap<(),()>> から変更）
+    let mut exposed_ports: Vec<String> = Vec::new();
 
     for port in &service.ports {
         let container_port = format!(
@@ -68,7 +69,7 @@ pub fn service_to_container_config_with_network(
         );
 
         // ポート公開設定
-        exposed_ports.insert(container_port.clone(), HashMap::new());
+        exposed_ports.push(container_port.clone());
 
         // ホストポートバインディング
         let host_ip = port.host_ip.as_deref().unwrap_or("0.0.0.0");
@@ -273,8 +274,8 @@ mod tests {
         let (config, _) = service_to_container_config("web", &service, "local", "test");
 
         let exposed_ports = config.exposed_ports.unwrap();
-        assert!(exposed_ports.contains_key("3000/tcp"));
-        assert!(exposed_ports.contains_key("5432/tcp"));
+        assert!(exposed_ports.contains(&"3000/tcp".to_string()));
+        assert!(exposed_ports.contains(&"5432/tcp".to_string()));
 
         let host_config = config.host_config.unwrap();
         let port_bindings = host_config.port_bindings.unwrap();
@@ -304,7 +305,7 @@ mod tests {
         let (config, _) = service_to_container_config("dns", &service, "local", "test");
 
         let exposed_ports = config.exposed_ports.unwrap();
-        assert!(exposed_ports.contains_key("53/udp"));
+        assert!(exposed_ports.contains(&"53/udp".to_string()));
     }
 
     #[test]

--- a/crates/fleetflow/src/docker.rs
+++ b/crates/fleetflow/src/docker.rs
@@ -38,21 +38,21 @@ async fn pull_image_inner(
 
     while let Some(info) = stream.next().await {
         match info {
+            // bollard 0.21: 整形済み progress 文字列が廃止 → progress_detail から再構成
             Ok(bollard::models::CreateImageInfo {
                 status: Some(status),
-                progress: Some(progress),
+                progress_detail,
                 ..
             }) => {
-                print!("\r  ↓ {}: {}", status, progress);
+                let progress = progress_detail.and_then(|pd| match (pd.current, pd.total) {
+                    (Some(c), Some(t)) if t > 0 => Some(format!("{c}/{t}")),
+                    _ => None,
+                });
                 use std::io::Write;
-                std::io::stdout().flush()?;
-            }
-            Ok(bollard::models::CreateImageInfo {
-                status: Some(status),
-                ..
-            }) => {
-                print!("\r  ↓ {}                    ", status);
-                use std::io::Write;
+                match progress {
+                    Some(p) => print!("\r  ↓ {}: {}", status, p),
+                    None => print!("\r  ↓ {}                    ", status),
+                }
                 std::io::stdout().flush()?;
             }
             Err(e) => {


### PR DESCRIPTION
## 概要

`bollard`（Docker API client）を 0.19 → 0.21 に更新。dependabot #180 を **supersede**（#180 はコンパイルエラーのまま放置されていたため、コード適合を加えた本 PR で置き換え）。

## bollard 0.21 の破壊的変更（4 箇所）

bollard 0.21 で Docker API モデルが正規化された：

| 変更 | 対応ファイル |
|------|------|
| `ContainerCreateBody.exposed_ports`: `HashMap<String, HashMap<(),()>>` → `Vec<String>` | `converter.rs`（構築を `push` ベースに、テストを `contains` に） |
| `PushImageInfo.error: Option<String>` → `error_detail: Option<ErrorDetail>` | `pusher.rs`（`.message` を取り出す） |
| `PushImageInfo.progress` / `CreateImageInfo.progress`: 整形済み文字列が廃止 → `progress_detail`(current/total) のみ | `pusher.rs` / `docker.rs`（`"c/t"` 形式で再構成） |

`exposed_ports` は Docker API の `map[string]struct{}`（空構造体の集合）を bollard が `Vec<String>` というRust らしい集合表現に整理したもの。progress は整形済み文字列が廃止され、生の current/total バイト数のみになった。

## 検証

- `cargo build --workspace` ✓
- `cargo test --workspace` ✓（全テスト pass / 0 fail）
- `cargo clippy --workspace --all-targets` ✓
- `cargo fmt --check` ✓

## 関連

- supersedes #180（dependabot/cargo/bollard-0.21、コード適合なしでコンパイル不可だった）

🤖 Generated with [Claude Code](https://claude.com/claude-code)