### PR TITLE
feat(agent,cp): fleet-agent observability — multi-runtime inventory (#185)

### DIFF
--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -6,8 +6,9 @@ use std::time::{Duration, Instant};
 
 use bollard::Docker;
 use bollard::query_parameters::{InspectContainerOptions, ListContainersOptions};
+use serde::Serialize;
 use serde_json::json;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 use unison::network::client::ProtocolClient;
 
 /// モニター設定
@@ -83,16 +84,169 @@ impl Severity {
 /// クールダウンキー: (container_name, alert_type)
 type CooldownKey = (String, String);
 
+/// 観測対象の container runtime endpoint。
+struct RuntimeEndpoint {
+    /// runtime 識別子（"docker" | "podman-rootless-<uid>"）
+    id: String,
+    docker: Docker,
+}
+
+/// rootless Podman socket path から runtime_id を導出する（純粋関数）。
+///
+/// `/run/user/1000/podman/podman.sock` → `podman-rootless-1000`
+fn podman_runtime_id(socket_path: &str) -> String {
+    let uid = socket_path
+        .strip_prefix("/run/user/")
+        .and_then(|rest| rest.split('/').next())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("unknown");
+    format!("podman-rootless-{uid}")
+}
+
+/// `/run/user/*/podman/podman.sock` を列挙する（rootless Podman socket）。
+fn discover_podman_sockets() -> Vec<String> {
+    let mut sockets = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/run/user") else {
+        return sockets;
+    };
+    for entry in entries.flatten() {
+        let sock = entry.path().join("podman/podman.sock");
+        if sock.exists()
+            && let Some(s) = sock.to_str()
+        {
+            sockets.push(s.to_string());
+        }
+    }
+    sockets
+}
+
+/// container runtime を auto-discovery する。
+///
+/// - root Docker: `connect_with_local_defaults`（常に試行、socket 無ければ除外）
+/// - rootless Podman: `/run/user/*/podman/podman.sock` を glob、存在分のみ
+///
+/// socket の存在 = opt-in。接続失敗は warn してスキップ（fail-soft）。
+fn discover_runtimes() -> Vec<RuntimeEndpoint> {
+    let mut runtimes = Vec::new();
+
+    match Docker::connect_with_local_defaults() {
+        Ok(docker) => runtimes.push(RuntimeEndpoint {
+            id: "docker".to_string(),
+            docker,
+        }),
+        Err(e) => debug!(error = %e, "root Docker 未接続 — スキップ"),
+    }
+
+    for path in discover_podman_sockets() {
+        let unix_url = format!("unix://{path}");
+        match Docker::connect_with_unix(&unix_url, 120, bollard::API_DEFAULT_VERSION) {
+            Ok(docker) => runtimes.push(RuntimeEndpoint {
+                id: podman_runtime_id(&path),
+                docker,
+            }),
+            Err(e) => warn!(socket = %path, error = %e, "Podman socket 接続失敗 — スキップ"),
+        }
+    }
+
+    runtimes
+}
+
+/// container の labels から fleetflow attribution（project/stage/service）を
+/// 抽出する（純粋関数）。Quadlet `.container` units にも同 label を付与する。
+fn extract_attribution(
+    labels: &HashMap<String, String>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    (
+        labels.get("fleetflow.project").cloned(),
+        labels.get("fleetflow.stage").cloned(),
+        labels.get("fleetflow.service").cloned(),
+    )
+}
+
+/// inventory entry — `inventory_report` の wire 形式に対応。
+#[derive(Debug, Clone, Serialize)]
+struct ContainerInventoryEntry {
+    runtime: String,
+    container_id: String,
+    container_name: String,
+    status: String,
+    health: Option<String>,
+    image: Option<String>,
+    project: Option<String>,
+    stage: Option<String>,
+    service: Option<String>,
+}
+
+/// 1 runtime の全 container を inventory entry に変換する。
+async fn collect_runtime_inventory(
+    rt: &RuntimeEndpoint,
+) -> anyhow::Result<Vec<ContainerInventoryEntry>> {
+    let containers = rt
+        .docker
+        .list_containers(Some(ListContainersOptions {
+            all: true,
+            ..Default::default()
+        }))
+        .await?;
+
+    let mut entries = Vec::new();
+    for c in &containers {
+        let Some(container_id) = c.id.clone() else {
+            continue;
+        };
+        let container_name = c
+            .names
+            .as_ref()
+            .and_then(|n| n.first())
+            .map(|n| n.trim_start_matches('/').to_string())
+            .unwrap_or_default();
+        let labels = c.labels.clone().unwrap_or_default();
+        let (project, stage, service) = extract_attribution(&labels);
+        let status = c.state.as_ref().map(|s| s.to_string()).unwrap_or_default();
+        let health = c
+            .health
+            .as_ref()
+            .and_then(|h| h.status.as_ref())
+            .map(|s| s.to_string());
+
+        entries.push(ContainerInventoryEntry {
+            runtime: rt.id.clone(),
+            container_id,
+            container_name,
+            status,
+            health,
+            image: c.image.clone(),
+            project,
+            stage,
+            service,
+        });
+    }
+    Ok(entries)
+}
+
+/// CP に inventory snapshot を送信する（#185）。`server` チャネルの
+/// `inventory_report` method。
+async fn send_inventory_report(
+    client: &ProtocolClient,
+    server_slug: &str,
+    entries: &[ContainerInventoryEntry],
+) -> anyhow::Result<()> {
+    let channel = client.open_channel("server").await?;
+    let _: serde_json::Value = channel
+        .request(
+            "inventory_report",
+            &json!({
+                "server_slug": server_slug,
+                "containers": entries,
+            }),
+        )
+        .await?;
+    channel.close().await.ok();
+    Ok(())
+}
+
 /// モニターループを実行
 pub async fn run_loop(client: &Arc<ProtocolClient>, server_slug: &str, config: &MonitorConfig) {
-    let docker = match Docker::connect_with_local_defaults() {
-        Ok(d) => d,
-        Err(e) => {
-            error!(error = %e, "Docker 接続失敗 — モニター停止");
-            return;
-        }
-    };
-
     info!(
         interval = config.interval_secs,
         threshold = config.restart_threshold,
@@ -105,53 +259,86 @@ pub async fn run_loop(client: &Arc<ProtocolClient>, server_slug: &str, config: &
     loop {
         tokio::time::sleep(Duration::from_secs(config.interval_secs)).await;
 
-        match check_containers(&docker, &prev_states, config).await {
-            Ok(result) => {
-                for alert in &result.alerts {
-                    let key = (
-                        alert.container_name.clone(),
-                        alert.alert_type.as_str().to_string(),
-                    );
+        // runtime を毎 interval 再 discovery（rootless socket は agent 起動後に
+        // 現れうるため）。
+        let runtimes = discover_runtimes();
+        if runtimes.is_empty() {
+            warn!("観測可能な container runtime が無い — このサイクルをスキップ");
+            continue;
+        }
 
-                    // クールダウンチェック
-                    if let Some(last_sent) = cooldowns.get(&key)
-                        && last_sent.elapsed() < Duration::from_secs(config.alert_cooldown_secs)
-                    {
-                        debug!(
-                            container = %alert.container_name,
-                            alert_type = alert.alert_type.as_str(),
-                            "クールダウン中 — アラートスキップ"
+        // ── 異常検知: root Docker のみ（既存挙動を維持）──
+        // Quadlet (rootless Podman) は healthcheck 未定義 + systemd 管理で
+        // restart_count が死角のため anomaly alert の対象外（#185 既知の限界）。
+        if let Some(docker_rt) = runtimes.iter().find(|r| r.id == "docker") {
+            match check_containers(&docker_rt.docker, &prev_states, config).await {
+                Ok(result) => {
+                    for alert in &result.alerts {
+                        let key = (
+                            alert.container_name.clone(),
+                            alert.alert_type.as_str().to_string(),
                         );
-                        continue;
+
+                        // クールダウンチェック
+                        if let Some(last_sent) = cooldowns.get(&key)
+                            && last_sent.elapsed() < Duration::from_secs(config.alert_cooldown_secs)
+                        {
+                            debug!(
+                                container = %alert.container_name,
+                                alert_type = alert.alert_type.as_str(),
+                                "クールダウン中 — アラートスキップ"
+                            );
+                            continue;
+                        }
+
+                        // CP にアラート送信
+                        if let Err(e) = send_alert(client, server_slug, alert).await {
+                            warn!(error = %e, "アラート送信失敗");
+                        } else {
+                            cooldowns.insert(key, Instant::now());
+                            info!(
+                                container = %alert.container_name,
+                                alert_type = alert.alert_type.as_str(),
+                                severity = alert.severity.as_str(),
+                                "アラート送信完了"
+                            );
+                        }
                     }
 
-                    // CP にアラート送信
-                    if let Err(e) = send_alert(client, server_slug, alert).await {
-                        warn!(error = %e, "アラート送信失敗");
-                    } else {
-                        cooldowns.insert(key, Instant::now());
-                        info!(
-                            container = %alert.container_name,
-                            alert_type = alert.alert_type.as_str(),
-                            severity = alert.severity.as_str(),
-                            "アラート送信完了"
-                        );
+                    // 正常復帰 → CP に resolve 送信
+                    for container_name in &result.recovered {
+                        if let Err(e) = send_resolve(client, server_slug, container_name).await {
+                            warn!(error = %e, container = %container_name, "resolve 送信失敗");
+                        } else {
+                            info!(container = %container_name, "コンテナ正常復帰 — アラート解決送信");
+                        }
                     }
+
+                    prev_states = result.new_states;
                 }
-
-                // 正常復帰 → CP に resolve 送信
-                for container_name in &result.recovered {
-                    if let Err(e) = send_resolve(client, server_slug, container_name).await {
-                        warn!(error = %e, container = %container_name, "resolve 送信失敗");
-                    } else {
-                        info!(container = %container_name, "コンテナ正常復帰 — アラート解決送信");
-                    }
+                Err(e) => {
+                    warn!(error = %e, "コンテナチェック失敗");
                 }
-
-                prev_states = result.new_states;
             }
+        }
+
+        // ── inventory: 全 runtime（#185）──
+        // dead socket 対策で各 runtime 列挙を timeout で囲む（fail-soft）。
+        let mut inventory = Vec::new();
+        for rt in &runtimes {
+            match tokio::time::timeout(Duration::from_secs(10), collect_runtime_inventory(rt)).await
+            {
+                Ok(Ok(entries)) => inventory.extend(entries),
+                Ok(Err(e)) => {
+                    warn!(runtime = %rt.id, error = %e, "inventory 収集失敗 — スキップ")
+                }
+                Err(_) => warn!(runtime = %rt.id, "inventory 収集 timeout — スキップ"),
+            }
+        }
+        match send_inventory_report(client, server_slug, &inventory).await {
+            Ok(()) => debug!(count = inventory.len(), "inventory_report 送信完了"),
             Err(e) => {
-                warn!(error = %e, "コンテナチェック失敗");
+                warn!(error = %e, count = inventory.len(), "inventory_report 送信失敗")
             }
         }
     }
@@ -360,6 +547,53 @@ async fn send_alert(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── #185 multi-runtime observability ──
+
+    #[test]
+    fn podman_runtime_id_extracts_uid() {
+        assert_eq!(
+            podman_runtime_id("/run/user/1000/podman/podman.sock"),
+            "podman-rootless-1000"
+        );
+        assert_eq!(
+            podman_runtime_id("/run/user/0/podman/podman.sock"),
+            "podman-rootless-0"
+        );
+    }
+
+    #[test]
+    fn podman_runtime_id_handles_unexpected_path() {
+        // 想定外 path でも panic せず "unknown" にフォールバック
+        assert_eq!(
+            podman_runtime_id("/tmp/podman.sock"),
+            "podman-rootless-unknown"
+        );
+    }
+
+    #[test]
+    fn extract_attribution_reads_fleetflow_labels() {
+        let mut labels = HashMap::new();
+        labels.insert("fleetflow.project".to_string(), "fleetstage".to_string());
+        labels.insert("fleetflow.stage".to_string(), "live".to_string());
+        labels.insert("fleetflow.service".to_string(), "hq-api".to_string());
+        labels.insert("other.label".to_string(), "ignored".to_string());
+
+        let (project, stage, service) = extract_attribution(&labels);
+        assert_eq!(project.as_deref(), Some("fleetstage"));
+        assert_eq!(stage.as_deref(), Some("live"));
+        assert_eq!(service.as_deref(), Some("hq-api"));
+    }
+
+    #[test]
+    fn extract_attribution_missing_labels_are_none() {
+        // fleetflow.* label を持たない container（attribution 不明）
+        let labels = HashMap::new();
+        let (project, stage, service) = extract_attribution(&labels);
+        assert!(project.is_none());
+        assert!(stage.is_none());
+        assert!(service.is_none());
+    }
 
     fn default_config() -> MonitorConfig {
         MonitorConfig {

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -1129,6 +1129,67 @@ impl Database {
     }
 
     // ─────────────────────────────────────────
+    // ObservedContainer (#185 fleet-agent observability)
+    // ─────────────────────────────────────────
+
+    /// server の observed_container snapshot を丸ごと差し替える。
+    ///
+    /// `inventory_report` 毎に呼ばれ、その server の旧 record を全削除して
+    /// 新スナップショットを挿入する（最新 snapshot のみ保持 — 履歴は持たない）。
+    pub async fn replace_observed_containers(
+        &self,
+        server_slug: &str,
+        containers: &[ObservedContainer],
+    ) -> Result<()> {
+        self.db
+            .query("DELETE observed_container WHERE server_slug = $server_slug")
+            .bind(("server_slug", server_slug.to_string()))
+            .await
+            .context("observed_container 旧 snapshot 削除失敗")?;
+
+        for c in containers {
+            // server_slug は引数を権威とする（DELETE と CREATE で同一スコープに
+            // 揃え、c.server_slug との食い違いによる不整合を防ぐ）。
+            self.db
+                .query(
+                    "CREATE observed_container CONTENT { server_slug: $server_slug, runtime: $runtime, container_id: $container_id, container_name: $container_name, status: $status, health: $health, image: $image, project: $project, stage: $stage, service: $service, started_at: $started_at, last_seen_at: $last_seen_at }",
+                )
+                .bind(("server_slug", server_slug.to_string()))
+                .bind(("runtime", c.runtime.clone()))
+                .bind(("container_id", c.container_id.clone()))
+                .bind(("container_name", c.container_name.clone()))
+                .bind(("status", c.status.clone()))
+                .bind(("health", c.health.clone()))
+                .bind(("image", c.image.clone()))
+                .bind(("project", c.project.clone()))
+                .bind(("stage", c.stage.clone()))
+                .bind(("service", c.service.clone()))
+                .bind(("started_at", c.started_at))
+                .bind(("last_seen_at", c.last_seen_at))
+                .await
+                .context("observed_container 挿入失敗")?;
+        }
+        Ok(())
+    }
+
+    /// server の observed_container 一覧（最新 snapshot）を取得。
+    pub async fn list_observed_containers(
+        &self,
+        server_slug: &str,
+    ) -> Result<Vec<ObservedContainer>> {
+        let mut result = self
+            .db
+            .query(
+                "SELECT * FROM observed_container WHERE server_slug = $server_slug ORDER BY container_name",
+            )
+            .bind(("server_slug", server_slug.to_string()))
+            .await
+            .context("observed_container 一覧取得失敗")?;
+        let containers: Vec<ObservedContainer> = result.take(0)?;
+        Ok(containers)
+    }
+
+    // ─────────────────────────────────────────
     // Volume CRUD (Persistence Volume Tier P-1, 2026-04-23)
     //
     // 詳細設計: fleetstage repo docs/design/20-persistence-volume-tier.md
@@ -1699,6 +1760,24 @@ DEFINE FIELD IF NOT EXISTS started_at ON build_job TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS finished_at ON build_job TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS duration_seconds ON build_job TYPE option<int>;
 DEFINE INDEX IF NOT EXISTS idx_build_job_tenant_state ON build_job FIELDS tenant, state;
+
+-- #185: fleet-agent observability — monitor が全 runtime から観測した container
+-- の inventory snapshot。inventory_report 毎に server 単位で全置換（最新のみ保持）。
+-- 既存 `container` と別テーブル: `container` は service FK 必須で Quadlet を弾くため。
+DEFINE TABLE IF NOT EXISTS observed_container SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS server_slug ON observed_container TYPE string;
+DEFINE FIELD IF NOT EXISTS runtime ON observed_container TYPE string;
+DEFINE FIELD IF NOT EXISTS container_id ON observed_container TYPE string;
+DEFINE FIELD IF NOT EXISTS container_name ON observed_container TYPE string;
+DEFINE FIELD IF NOT EXISTS status ON observed_container TYPE string;
+DEFINE FIELD IF NOT EXISTS health ON observed_container TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS image ON observed_container TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS project ON observed_container TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS stage ON observed_container TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS service ON observed_container TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS started_at ON observed_container TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS last_seen_at ON observed_container TYPE option<datetime> DEFAULT time::now();
+DEFINE INDEX IF NOT EXISTS idx_observed_container_server ON observed_container FIELDS server_slug;
 "#;
 
 #[cfg(test)]
@@ -1709,6 +1788,65 @@ mod tests {
     async fn test_connect_memory() {
         let db = Database::connect_memory().await;
         assert!(db.is_ok(), "in-memory 接続に失敗: {:?}", db.err());
+    }
+
+    /// #185: observed_container は inventory_report 毎に snapshot 全置換される。
+    /// 2 件 → 1 件で list したとき append でなく overwrite されることを検証。
+    #[tokio::test]
+    async fn test_observed_container_snapshot_replace() {
+        let db = Database::connect_memory().await.unwrap();
+
+        let mk = |name: &str, runtime: &str| ObservedContainer {
+            id: None,
+            server_slug: "worker-01".into(),
+            runtime: runtime.into(),
+            container_id: format!("id-{name}"),
+            container_name: name.into(),
+            status: "running".into(),
+            health: None,
+            image: Some("ghcr.io/x:latest".into()),
+            project: Some("fleetstage".into()),
+            stage: Some("live".into()),
+            service: Some(name.into()),
+            started_at: None,
+            last_seen_at: None,
+        };
+
+        // 初回 snapshot: 2 件（Docker + Podman runtime 混在）
+        db.replace_observed_containers(
+            "worker-01",
+            &[
+                mk("hq-api", "docker"),
+                mk("backstage", "podman-rootless-1000"),
+            ],
+        )
+        .await
+        .unwrap();
+        let listed = db.list_observed_containers("worker-01").await.unwrap();
+        assert_eq!(listed.len(), 2, "初回 snapshot は 2 件");
+
+        // 2 回目 snapshot: 1 件 → overwrite（append でないことを検証）
+        db.replace_observed_containers("worker-01", &[mk("hq-api", "docker")])
+            .await
+            .unwrap();
+        let listed = db.list_observed_containers("worker-01").await.unwrap();
+        assert_eq!(listed.len(), 1, "snapshot は overwrite され 1 件");
+        assert_eq!(listed[0].container_name, "hq-api");
+        assert_eq!(listed[0].runtime, "docker");
+        assert_eq!(listed[0].project.as_deref(), Some("fleetstage"));
+
+        // 別 server の snapshot は影響を受けない
+        db.replace_observed_containers("worker-02", &[mk("other", "docker")])
+            .await
+            .unwrap();
+        assert_eq!(
+            db.list_observed_containers("worker-01")
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "別 server の置換は worker-01 に影響しない"
+        );
     }
 
     #[tokio::test]

--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -1141,11 +1141,15 @@ impl Database {
         server_slug: &str,
         containers: &[ObservedContainer],
     ) -> Result<()> {
+        // SurrealDB の query は文単位のエラーを Response に内包するため、
+        // .check() を呼ばないとサイドエラーがサイレントに見逃される。
         self.db
             .query("DELETE observed_container WHERE server_slug = $server_slug")
             .bind(("server_slug", server_slug.to_string()))
             .await
-            .context("observed_container 旧 snapshot 削除失敗")?;
+            .context("observed_container 旧 snapshot 削除失敗")?
+            .check()
+            .context("observed_container DELETE クエリエラー")?;
 
         for c in containers {
             // server_slug は引数を権威とする（DELETE と CREATE で同一スコープに
@@ -1167,7 +1171,9 @@ impl Database {
                 .bind(("started_at", c.started_at))
                 .bind(("last_seen_at", c.last_seen_at))
                 .await
-                .context("observed_container 挿入失敗")?;
+                .context("observed_container 挿入失敗")?
+                .check()
+                .context("observed_container CREATE クエリエラー")?;
         }
         Ok(())
     }

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -750,6 +750,21 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             // container snapshot を server 単位で全置換する。
                             let server_slug =
                                 payload["server_slug"].as_str().unwrap_or_default();
+
+                            // server_slug 無指定での全置換は危険（空文字 WHERE で
+                            // 意図しない範囲を DELETE しうる）。alert ハンドラと同様に
+                            // 早期リターンで防御する。
+                            if server_slug.is_empty() {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "inventory_report",
+                                        &json!({ "error": "server_slug missing" }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+
                             let containers = parse_inventory_payload(&payload);
 
                             match state

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -6,8 +6,51 @@ use tracing::{error, info};
 use unison::network::channel::UnisonChannel;
 use unison::network::server::ProtocolServer;
 
-use crate::model::{Alert, Server, ServerStatusUpdate};
+use crate::model::{Alert, ObservedContainer, Server, ServerStatusUpdate};
 use crate::server::AppState;
+
+/// `inventory_report` payload の `containers` 配列を `Vec<ObservedContainer>` に
+/// 変換する（純粋関数 — テスト可能）。
+///
+/// agent (fleet-agent monitor) が送る wire 形式:
+/// `{ server_slug, containers: [{ runtime, container_id, container_name,
+///    status, health?, image?, project?, stage?, service?, started_at? }] }`
+fn parse_inventory_payload(payload: &serde_json::Value) -> Vec<ObservedContainer> {
+    let server_slug = payload["server_slug"].as_str().unwrap_or_default();
+    let now = Utc::now();
+    payload["containers"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| {
+                    // container_id / container_name は必須。欠落要素はスキップ。
+                    let container_id = c["container_id"].as_str()?.to_string();
+                    let container_name = c["container_name"].as_str()?.to_string();
+                    let opt_str =
+                        |key: &str| -> Option<String> { c[key].as_str().map(str::to_string) };
+                    Some(ObservedContainer {
+                        id: None,
+                        server_slug: server_slug.to_string(),
+                        runtime: c["runtime"].as_str().unwrap_or("unknown").to_string(),
+                        container_id,
+                        container_name,
+                        status: c["status"].as_str().unwrap_or("unknown").to_string(),
+                        health: opt_str("health"),
+                        image: opt_str("image"),
+                        project: opt_str("project"),
+                        stage: opt_str("stage"),
+                        service: opt_str("service"),
+                        started_at: c["started_at"]
+                            .as_str()
+                            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                            .map(|dt| dt.with_timezone(&Utc)),
+                        last_seen_at: Some(now),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
     server
@@ -702,6 +745,44 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 }
                             }
                         }
+                        "inventory_report" => {
+                            // #185: agent monitor が全 runtime から観測した
+                            // container snapshot を server 単位で全置換する。
+                            let server_slug =
+                                payload["server_slug"].as_str().unwrap_or_default();
+                            let containers = parse_inventory_payload(&payload);
+
+                            match state
+                                .db
+                                .replace_observed_containers(server_slug, &containers)
+                                .await
+                            {
+                                Ok(()) => {
+                                    info!(
+                                        server = server_slug,
+                                        count = containers.len(),
+                                        "inventory_report 記録完了"
+                                    );
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "inventory_report",
+                                            &json!({ "ack": true, "count": containers.len() }),
+                                        )
+                                        .await?;
+                                }
+                                Err(e) => {
+                                    error!(error = %e, "inventory_report 記録失敗");
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "inventory_report",
+                                            &json!({ "error": e.to_string() }),
+                                        )
+                                        .await?;
+                                }
+                            }
+                        }
                         "ping" => {
                             let hostname = payload["hostname"].as_str().unwrap_or_default();
 
@@ -747,4 +828,70 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
             })
         })
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_inventory_payload;
+    use serde_json::json;
+
+    /// agent の wire 形式を ObservedContainer に変換できる。
+    #[test]
+    fn parse_inventory_payload_well_formed() {
+        let payload = json!({
+            "server_slug": "worker-01",
+            "containers": [
+                {
+                    "runtime": "podman-rootless-1000",
+                    "container_id": "abc123",
+                    "container_name": "fleetstage-hq-api",
+                    "status": "running",
+                    "image": "ghcr.io/x/hq-api:latest",
+                    "project": "fleetstage",
+                    "stage": "live",
+                    "service": "hq-api",
+                },
+            ],
+        });
+        let containers = parse_inventory_payload(&payload);
+        assert_eq!(containers.len(), 1);
+        let c = &containers[0];
+        assert_eq!(c.server_slug, "worker-01");
+        assert_eq!(c.runtime, "podman-rootless-1000");
+        assert_eq!(c.container_name, "fleetstage-hq-api");
+        assert_eq!(c.project.as_deref(), Some("fleetstage"));
+        assert_eq!(c.stage.as_deref(), Some("live"));
+        assert!(c.last_seen_at.is_some(), "last_seen_at は CP 側で付与");
+        assert!(c.id.is_none());
+    }
+
+    /// container_id / container_name 欠落要素はスキップ、optional 欠落は None。
+    #[test]
+    fn parse_inventory_payload_skips_invalid_and_defaults_optionals() {
+        let payload = json!({
+            "server_slug": "worker-01",
+            "containers": [
+                { "container_id": "ok", "container_name": "valid" },
+                { "container_id": "no-name" },          // container_name 欠落 → skip
+                { "container_name": "no-id" },          // container_id 欠落 → skip
+            ],
+        });
+        let containers = parse_inventory_payload(&payload);
+        assert_eq!(containers.len(), 1, "必須欠落要素はスキップされる");
+        let c = &containers[0];
+        assert_eq!(c.container_name, "valid");
+        assert_eq!(c.runtime, "unknown", "runtime 欠落時は unknown");
+        assert_eq!(c.status, "unknown", "status 欠落時は unknown");
+        assert!(c.project.is_none());
+        assert!(c.image.is_none());
+    }
+
+    /// containers キー欠落・空でも panic せず空 Vec。
+    #[test]
+    fn parse_inventory_payload_empty() {
+        assert!(parse_inventory_payload(&json!({ "server_slug": "w" })).is_empty());
+        assert!(
+            parse_inventory_payload(&json!({ "server_slug": "w", "containers": [] })).is_empty()
+        );
+    }
 }

--- a/crates/fleetflow-controlplane/src/model.rs
+++ b/crates/fleetflow-controlplane/src/model.rs
@@ -358,6 +358,39 @@ pub struct Container {
 }
 
 // ─────────────────────────────────────────────
+// CP-005b: ObservedContainer (#185 fleet-agent observability)
+// ─────────────────────────────────────────────
+
+/// fleet-agent monitor が観測した container の inventory snapshot 1 件。
+///
+/// 既存 `Container` (CP-005) と別系統:
+/// - `Container` は deploy が作る record で `service: RecordId` FK 必須 →
+///   Quadlet (rootless Podman) container は service 概念に紐付かず入らない。
+/// - `ObservedContainer` は monitor が全 runtime（root Docker + rootless
+///   Podman socket 群）から観測した実態を `inventory_report` 毎に上書き保存。
+///   project/stage/service は `fleetflow.*` label 由来の素の文字列（FK なし）。
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct ObservedContainer {
+    pub id: Option<RecordId>,
+    pub server_slug: String,
+    /// 観測元 runtime（"docker" | "podman-rootless-<uid>"）
+    pub runtime: String,
+    pub container_id: String,
+    pub container_name: String,
+    pub status: String,
+    pub health: Option<String>,
+    pub image: Option<String>,
+    /// `fleetflow.project` label 由来（attribution）
+    pub project: Option<String>,
+    /// `fleetflow.stage` label 由来
+    pub stage: Option<String>,
+    /// `fleetflow.service` label 由来
+    pub service: Option<String>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub last_seen_at: Option<DateTime<Utc>>,
+}
+
+// ─────────────────────────────────────────────
 // CP-006: Server
 // ─────────────────────────────────────────────
 


### PR DESCRIPTION
## 概要

Backstage が Quadlet (rootless Podman) 管理 container を `CONTAINERS / LAST DEPLOY: unknown` と表示する件を解消。fleet-agent の monitor を multi-runtime 化し、観測した container inventory を CP の新テーブルに push する。

Podman+Quadlet 追従 epic（`mem_1CbD3b6j1s3pxQ1TGvaXtv`）の **WS1**。closes #185。

## 背景

`mem_1CbAW7v5BJEMGc2EvFYqAR` の通り fleetstage は Quadlet 直管理が常態化。fleet-agent の monitor は `connect_with_local_defaults()` で root Docker socket 1 本のみを見ており、rootless Podman socket の Quadlet container が**不可視**だった。

## agent 側（`monitor.rs`）

- **runtime auto-discovery** — root Docker 固定 + `/run/user/*/podman/podman.sock` glob。socket 存在 = opt-in、接続失敗は fail-soft
- **`inventory_report` push** — 毎 interval、全 runtime の container snapshot を `server` チャネルで送信
- **attribution** — `fleetflow.{project,stage,service}` label を抽出
- 各 runtime 列挙を `tokio::timeout` で囲み dead socket をスキップ
- 異常検知は **root Docker のみ維持**（Quadlet は healthcheck 未定義で Unhealthy alert 不発 = #185 既知の限界）→ `prev_states` の name 衝突を回避

## CP 側（model / db / handler）

- **`ObservedContainer` モデル** — 既存 `Container`（`service` FK NOT NULL で Quadlet を弾く）と別系統。project/stage/service は label 由来の素の `Option<String>`
- **`observed_container` テーブル** — `SCHEMA_SQL` に追記（冪等 `DEFINE`）
- **`replace_observed_containers`** — server 単位の snapshot 全置換（最新のみ保持）。`server_slug` は引数を権威に統一し DELETE/CREATE の不整合を防止
- **`inventory_report` ハンドラ** — `server` チャネル

## テスト

- agent: `podman_runtime_id` / `extract_attribution` のユニット 4 件
- CP: `parse_inventory_payload` のユニット 3 件、`observed_container` の snapshot 上書き + server 分離の DB テスト

全 workspace build / test / clippy / fmt グリーン。

## 設計参照

#185（A〜D の設計、Team B 二重レビュー済）。spark `mem_1CbCM83d4x968J4qyu2gVq` で ratify 済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)