### PR TITLE
fix(agent): 全 runtime 列挙失敗時に inventory_report 送信をスキップ

### DIFF
--- a/crates/fleet-agent/src/monitor.rs
+++ b/crates/fleet-agent/src/monitor.rs
@@ -325,21 +325,32 @@ pub async fn run_loop(client: &Arc<ProtocolClient>, server_slug: &str, config: &
         // ── inventory: 全 runtime（#185）──
         // dead socket 対策で各 runtime 列挙を timeout で囲む（fail-soft）。
         let mut inventory = Vec::new();
+        let mut any_runtime_ok = false;
         for rt in &runtimes {
             match tokio::time::timeout(Duration::from_secs(10), collect_runtime_inventory(rt)).await
             {
-                Ok(Ok(entries)) => inventory.extend(entries),
+                Ok(Ok(entries)) => {
+                    any_runtime_ok = true;
+                    inventory.extend(entries);
+                }
                 Ok(Err(e)) => {
                     warn!(runtime = %rt.id, error = %e, "inventory 収集失敗 — スキップ")
                 }
                 Err(_) => warn!(runtime = %rt.id, "inventory 収集 timeout — スキップ"),
             }
         }
-        match send_inventory_report(client, server_slug, &inventory).await {
-            Ok(()) => debug!(count = inventory.len(), "inventory_report 送信完了"),
-            Err(e) => {
-                warn!(error = %e, count = inventory.len(), "inventory_report 送信失敗")
+        // 全 runtime の列挙が失敗したら空 snapshot を送らない。送ると CP 側で
+        // observed_container が false-clear される（次 interval で復元）。
+        // runtime が成功して container 0 件のケースは正当な空なので送信する。
+        if any_runtime_ok {
+            match send_inventory_report(client, server_slug, &inventory).await {
+                Ok(()) => debug!(count = inventory.len(), "inventory_report 送信完了"),
+                Err(e) => {
+                    warn!(error = %e, count = inventory.len(), "inventory_report 送信失敗")
+                }
             }
+        } else {
+            warn!("全 runtime の inventory 収集に失敗 — inventory_report 送信スキップ");
         }
     }
 }


### PR DESCRIPTION
## 概要

#187 (fleet-agent observability) の follow-up。Moody Blues がレビューでスコープ外として記録した false-clear バグを修正。

## 問題

全 runtime の container 列挙が同時失敗（timeout / error）すると、空の inventory が CP に送られ `observed_container` テーブルが全削除される。Backstage が 30s 間「0 件」と表示し、次 interval で復元される（self-healing だが flicker）。

## 修正

1 つ以上の runtime が列挙に成功した時のみ `inventory_report` を送信する。

- runtime が成功して container 0 件 → 正当な空 → 従来通り送信（正しく clear）
- 全 runtime が失敗 → 送信スキップ（false-clear を防ぐ、次 interval で再試行）

`any_runtime_ok` フラグで両者を区別。

## 検証

- `cargo build -p fleet-agent` ✓
- `cargo test -p fleet-agent` ✓（29 passed）
- clippy / fmt ✓

epic: mem_1CbD3b6j1s3pxQ1TGvaXtv (WS1 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)