### PR TITLE
feat(core): KDL stage に runtime フィールド — backend 明示宣言 (WS2)

### DIFF
--- a/crates/fleetflow-container/src/converter.rs
+++ b/crates/fleetflow-container/src/converter.rs
@@ -365,6 +365,7 @@ mod tests {
                 servers: vec![],
                 variables: HashMap::new(),
                 registry: None,
+                ..Default::default()
             },
         );
 

--- a/crates/fleetflow-container/src/engine.rs
+++ b/crates/fleetflow-container/src/engine.rs
@@ -529,6 +529,7 @@ mod tests {
                 servers: vec![],
                 variables: std::collections::HashMap::new(),
                 registry: None,
+                ..Default::default()
             },
         );
         Flow {

--- a/crates/fleetflow-container/tests/engine_test.rs
+++ b/crates/fleetflow-container/tests/engine_test.rs
@@ -21,6 +21,7 @@ fn make_flow(services: Vec<(&str, Service)>, stage_services: Vec<&str>) -> Flow 
             servers: vec![],
             variables: HashMap::new(),
             registry: None,
+            ..Default::default()
         },
     );
     Flow {

--- a/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
+++ b/crates/fleetflow-controlplane/tests/deploy_execute_test.rs
@@ -76,6 +76,7 @@ fn make_test_flow() -> Flow {
             servers: vec![],
             variables: HashMap::new(),
             registry: None,
+            ..Default::default()
         },
     );
 

--- a/crates/fleetflow-core/src/model/mod.rs
+++ b/crates/fleetflow-core/src/model/mod.rs
@@ -46,6 +46,7 @@ mod tests {
                 servers: vec![],
                 variables: HashMap::new(),
                 registry: None,
+                ..Default::default()
             },
         );
 

--- a/crates/fleetflow-core/src/model/stage.rs
+++ b/crates/fleetflow-core/src/model/stage.rs
@@ -3,6 +3,43 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// ステージの実行 backend（コンテナをどのランタイムで動かすか）。
+///
+/// Podman+Quadlet 追従 epic（creo-memories `mem_1CbD3b6j1s3pxQ1TGvaXtv`）WS2。
+/// stage ごとに明示宣言する（stage 名からの暗黙推論はしない — 慣習依存で脆い）。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Runtime {
+    /// Docker daemon（bollard 経由）— 既定。`runtime` 未宣言時はこれ。
+    #[default]
+    Docker,
+    /// Podman + Quadlet（systemd 管理の `.container`/`.network`）。
+    Quadlet,
+    /// Compose（`podman compose` / `docker compose`）。
+    Compose,
+}
+
+impl Runtime {
+    /// 文字列からパースする（KDL `runtime "..."` ノード用）。
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "docker" => Some(Self::Docker),
+            "quadlet" => Some(Self::Quadlet),
+            "compose" => Some(Self::Compose),
+            _ => None,
+        }
+    }
+
+    /// 文字列表現。
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Docker => "docker",
+            Self::Quadlet => "quadlet",
+            Self::Compose => "compose",
+        }
+    }
+}
+
 /// ステージ定義
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Stage {
@@ -18,4 +55,7 @@ pub struct Stage {
     /// ステージ固有のコンテナレジストリURL（例: ghcr.io/owner）
     #[serde(default)]
     pub registry: Option<String>,
+    /// 実行 backend。KDL `runtime "quadlet"` で宣言。未宣言時は `Docker`。
+    #[serde(default)]
+    pub runtime: Runtime,
 }

--- a/crates/fleetflow-core/src/parser/stage.rs
+++ b/crates/fleetflow-core/src/parser/stage.rs
@@ -1,7 +1,7 @@
 //! ステージノードのパース
 
 use crate::error::{FlowError, Result};
-use crate::model::{Service, Stage};
+use crate::model::{Runtime, Service, Stage};
 use crate::parser::service::parse_service;
 use kdl::KdlNode;
 use std::collections::HashMap;
@@ -66,6 +66,23 @@ pub fn parse_stage(node: &KdlNode) -> Result<(String, Stage, HashMap<String, Ser
                         .first()
                         .and_then(|e| e.value().as_string())
                         .map(|s| s.to_string());
+                }
+                // 実行 backend（WS2: docker | quadlet | compose、未宣言時 docker）
+                "runtime" => {
+                    let raw = child
+                        .entries()
+                        .first()
+                        .and_then(|e| e.value().as_string())
+                        .ok_or_else(|| {
+                            FlowError::InvalidConfig(
+                                "runtime requires a value (docker|quadlet|compose)".to_string(),
+                            )
+                        })?;
+                    stage.runtime = Runtime::parse(raw).ok_or_else(|| {
+                        FlowError::InvalidConfig(format!(
+                            "unknown runtime '{raw}' (expected docker|quadlet|compose)"
+                        ))
+                    })?;
                 }
                 _ => {}
             }

--- a/crates/fleetflow-core/src/parser/tests.rs
+++ b/crates/fleetflow-core/src/parser/tests.rs
@@ -496,6 +496,52 @@ fn test_parse_stage_with_servers() {
 }
 
 #[test]
+fn test_parse_stage_runtime_quadlet() {
+    // WS2: stage に runtime を明示宣言できる
+    let kdl = r#"
+        service "api" { image "node:20" }
+
+        stage "live" {
+            runtime "quadlet"
+            service "api"
+        }
+    "#;
+
+    let flow = parse_kdl_string(kdl, "test".to_string()).unwrap();
+    assert_eq!(flow.stages["live"].runtime, crate::model::Runtime::Quadlet);
+}
+
+#[test]
+fn test_parse_stage_runtime_defaults_to_docker() {
+    // runtime 未宣言の stage は Docker（後方互換）
+    let kdl = r#"
+        service "api" { image "node:20" }
+
+        stage "local" {
+            service "api"
+        }
+    "#;
+
+    let flow = parse_kdl_string(kdl, "test".to_string()).unwrap();
+    assert_eq!(flow.stages["local"].runtime, crate::model::Runtime::Docker);
+}
+
+#[test]
+fn test_parse_stage_runtime_invalid_is_error() {
+    // 未知の runtime 値はパースエラー
+    let kdl = r#"
+        service "api" { image "node:20" }
+
+        stage "live" {
+            runtime "k8s"
+            service "api"
+        }
+    "#;
+
+    assert!(parse_kdl_string(kdl, "test".to_string()).is_err());
+}
+
+#[test]
 fn test_parse_full_cloud_config() {
     let kdl = r#"
         project "creo-memories"


### PR DESCRIPTION
## 概要

Podman+Quadlet 追従 epic（`mem_1CbD3b6j1s3pxQ1TGvaXtv`）の **WS2 Stage 2a**。

stage がどの実行 backend でコンテナを動かすかを KDL で**明示宣言**できるようにする。epic 未決事項 #1 の決定 — 「明示宣言」（stage 名からの暗黙推論はしない、慣習依存で脆い）を materialize。

## 内容

- `Runtime` enum（`Docker` | `Quadlet` | `Compose`）を `model/stage.rs` に追加
- `Stage.runtime: Runtime` フィールド（未宣言時 `Docker` — 後方互換）
- stage パーサーに `runtime "quadlet"` 子ノード解析を追加（`registry` 子ノードと同じパターン）。未知の値はパースエラー

```kdl
stage "live" {
    runtime "quadlet"
    service "web"
}
```

## スコープ

backend を読んで実際に切り替える配線（`QuadletBackend` 適用層 + `Backend` trait + `fleet up` 配線）は **WS2 Stage 2b 以降**。本 PR は KDL に宣言を受け入れる土台のみ。

## テスト

3 件 — quadlet 宣言 / 未宣言時 docker（後方互換）/ 不正値エラー。既存 `Stage` リテラル 5 箇所は `..Default::default()` で追従。`cargo test` グリーン、clippy / fmt クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)