### PR TITLE
feat(cli): fleet up/down が Quadlet backend 対応 — Runtime→Backend (WS2)

### DIFF
--- a/crates/fleetflow-container/src/quadlet.rs
+++ b/crates/fleetflow-container/src/quadlet.rs
@@ -268,6 +268,11 @@ pub fn systemctl_user_start(unit: &str) -> io::Result<()> {
     run_systemctl_user(&["start", unit])
 }
 
+/// `systemctl --user stop <unit>`。
+pub fn systemctl_user_stop(unit: &str) -> io::Result<()> {
+    run_systemctl_user(&["stop", unit])
+}
+
 fn run_systemctl_user(args: &[&str]) -> io::Result<()> {
     let status = std::process::Command::new("systemctl")
         .arg("--user")

--- a/crates/fleetflow-core/src/model/stage.rs
+++ b/crates/fleetflow-core/src/model/stage.rs
@@ -3,14 +3,17 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// ステージの実行 backend（コンテナをどのランタイムで動かすか）。
+/// ステージの実行 backend（fleetflow がどの方式でコンテナを動かすか）。
 ///
 /// Podman+Quadlet 追従 epic（creo-memories `mem_1CbD3b6j1s3pxQ1TGvaXtv`）WS2。
 /// stage ごとに明示宣言する（stage 名からの暗黙推論はしない — 慣習依存で脆い）。
+///
+/// 注: これは「コンテナエンジン」そのものではなく fleetflow の駆動方式。
+/// `Quadlet` のエンジンは Podman（Quadlet は Docker には無い systemd 統合）。
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum Runtime {
-    /// Docker daemon（bollard 経由）— 既定。`runtime` 未宣言時はこれ。
+pub enum Backend {
+    /// Docker daemon を bollard API で駆動 — 既定。`backend` 未宣言時はこれ。
     #[default]
     Docker,
     /// Podman + Quadlet（systemd 管理の `.container`/`.network`）。
@@ -19,8 +22,8 @@ pub enum Runtime {
     Compose,
 }
 
-impl Runtime {
-    /// 文字列からパースする（KDL `runtime "..."` ノード用）。
+impl Backend {
+    /// 文字列からパースする（KDL `backend "..."` ノード用）。
     pub fn parse(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "docker" => Some(Self::Docker),
@@ -55,7 +58,7 @@ pub struct Stage {
     /// ステージ固有のコンテナレジストリURL（例: ghcr.io/owner）
     #[serde(default)]
     pub registry: Option<String>,
-    /// 実行 backend。KDL `runtime "quadlet"` で宣言。未宣言時は `Docker`。
+    /// 実行 backend。KDL `backend "quadlet"` で宣言。未宣言時は `Docker`。
     #[serde(default)]
-    pub runtime: Runtime,
+    pub backend: Backend,
 }

--- a/crates/fleetflow-core/src/parser/stage.rs
+++ b/crates/fleetflow-core/src/parser/stage.rs
@@ -1,7 +1,7 @@
 //! ステージノードのパース
 
 use crate::error::{FlowError, Result};
-use crate::model::{Runtime, Service, Stage};
+use crate::model::{Backend, Service, Stage};
 use crate::parser::service::parse_service;
 use kdl::KdlNode;
 use std::collections::HashMap;
@@ -68,19 +68,19 @@ pub fn parse_stage(node: &KdlNode) -> Result<(String, Stage, HashMap<String, Ser
                         .map(|s| s.to_string());
                 }
                 // 実行 backend（WS2: docker | quadlet | compose、未宣言時 docker）
-                "runtime" => {
+                "backend" => {
                     let raw = child
                         .entries()
                         .first()
                         .and_then(|e| e.value().as_string())
                         .ok_or_else(|| {
                             FlowError::InvalidConfig(
-                                "runtime requires a value (docker|quadlet|compose)".to_string(),
+                                "backend requires a value (docker|quadlet|compose)".to_string(),
                             )
                         })?;
-                    stage.runtime = Runtime::parse(raw).ok_or_else(|| {
+                    stage.backend = Backend::parse(raw).ok_or_else(|| {
                         FlowError::InvalidConfig(format!(
-                            "unknown runtime '{raw}' (expected docker|quadlet|compose)"
+                            "unknown backend '{raw}' (expected docker|quadlet|compose)"
                         ))
                     })?;
                 }

--- a/crates/fleetflow-core/src/parser/tests.rs
+++ b/crates/fleetflow-core/src/parser/tests.rs
@@ -496,24 +496,24 @@ fn test_parse_stage_with_servers() {
 }
 
 #[test]
-fn test_parse_stage_runtime_quadlet() {
-    // WS2: stage に runtime を明示宣言できる
+fn test_parse_stage_backend_quadlet() {
+    // WS2: stage に backend を明示宣言できる
     let kdl = r#"
         service "api" { image "node:20" }
 
         stage "live" {
-            runtime "quadlet"
+            backend "quadlet"
             service "api"
         }
     "#;
 
     let flow = parse_kdl_string(kdl, "test".to_string()).unwrap();
-    assert_eq!(flow.stages["live"].runtime, crate::model::Runtime::Quadlet);
+    assert_eq!(flow.stages["live"].backend, crate::model::Backend::Quadlet);
 }
 
 #[test]
-fn test_parse_stage_runtime_defaults_to_docker() {
-    // runtime 未宣言の stage は Docker（後方互換）
+fn test_parse_stage_backend_defaults_to_docker() {
+    // backend 未宣言の stage は Docker（後方互換）
     let kdl = r#"
         service "api" { image "node:20" }
 
@@ -523,17 +523,17 @@ fn test_parse_stage_runtime_defaults_to_docker() {
     "#;
 
     let flow = parse_kdl_string(kdl, "test".to_string()).unwrap();
-    assert_eq!(flow.stages["local"].runtime, crate::model::Runtime::Docker);
+    assert_eq!(flow.stages["local"].backend, crate::model::Backend::Docker);
 }
 
 #[test]
-fn test_parse_stage_runtime_invalid_is_error() {
-    // 未知の runtime 値はパースエラー
+fn test_parse_stage_backend_invalid_is_error() {
+    // 未知の backend 値はパースエラー
     let kdl = r#"
         service "api" { image "node:20" }
 
         stage "live" {
-            runtime "k8s"
+            backend "k8s"
             service "api"
         }
     "#;

--- a/crates/fleetflow/src/commands/down.rs
+++ b/crates/fleetflow/src/commands/down.rs
@@ -21,6 +21,17 @@ pub async fn handle(
         .get(&stage_name)
         .ok_or_else(|| anyhow::anyhow!("ステージ '{}' が見つかりません", stage_name))?;
 
+    // WS2: backend が Quadlet/Compose なら専用経路へ分岐
+    match stage_config.backend {
+        fleetflow_core::Backend::Docker => {}
+        fleetflow_core::Backend::Quadlet => {
+            return crate::commands::quadlet::down(config, &stage_name, stage_config, remove).await;
+        }
+        fleetflow_core::Backend::Compose => {
+            anyhow::bail!("backend \"compose\" は未実装です（epic WS4）");
+        }
+    }
+
     println!();
     println!(
         "{}",

--- a/crates/fleetflow/src/commands/mod.rs
+++ b/crates/fleetflow/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod down;
 pub mod exec;
 pub mod logs;
 pub mod ps;
+pub mod quadlet;
 pub mod registry;
 pub mod restart;
 pub mod up;

--- a/crates/fleetflow/src/commands/quadlet.rs
+++ b/crates/fleetflow/src/commands/quadlet.rs
@@ -1,0 +1,256 @@
+//! Quadlet backend — `fleet up` / `fleet down` の `runtime "quadlet"` 経路
+//!
+//! Podman+Quadlet 追従 epic（creo-memories `mem_1CbD3b6j1s3pxQ1TGvaXtv`）WS2 Stage 2c。
+//!
+//! stage が `runtime "quadlet"` を宣言しているとき、`up.rs` / `down.rs` から
+//! 本モジュールに分岐する。KDL から Quadlet ユニットを生成（`fleetflow-container`
+//! の `quadlet` モジュール）し、ホストの `~/.config/containers/systemd/` に
+//! 反映して `systemctl --user` で起動・停止する。
+//!
+//! 本経路は **`fleet up` をホスト上で実行する**ことを前提とする（CLI-local）。
+//! クラウドの CP→agent 経由デプロイは WS3（agent の Quadlet 役割転換）。
+
+use colored::Colorize;
+use fleetflow_container::quadlet::{
+    QuadletUnit, container_file_name, default_quadlet_dir, generate_container_unit,
+    generate_network_unit, network_file_name, sync_quadlet_dir, systemctl_user_daemon_reload,
+    systemctl_user_start, unit_base_name,
+};
+use fleetflow_core::{Flow, Stage};
+
+/// stage の全 container サービスから Quadlet ユニット束を組み立てる（純粋関数）。
+///
+/// `.network` 1 つ + container サービスごとの `.container`。静的サイト
+/// （`type "static"`）は Quadlet 対象外なのでスキップする。
+pub fn build_stage_units(
+    config: &Flow,
+    stage_name: &str,
+    stage: &Stage,
+) -> anyhow::Result<Vec<QuadletUnit>> {
+    let project = &config.name;
+    let mut units = vec![QuadletUnit {
+        file_name: network_file_name(project, stage_name),
+        content: generate_network_unit(project, stage_name),
+    }];
+
+    for service_name in &stage.services {
+        let service = config
+            .services
+            .get(service_name)
+            .ok_or_else(|| anyhow::anyhow!("サービス '{}' の定義が見つかりません", service_name))?;
+
+        // 静的サイトはコンテナではないため Quadlet 対象外
+        if service.is_static() {
+            continue;
+        }
+        if service.image.is_none() {
+            anyhow::bail!("サービス '{}' に image が指定されていません", service_name);
+        }
+
+        units.push(QuadletUnit {
+            file_name: container_file_name(project, stage_name, service_name),
+            content: generate_container_unit(
+                project,
+                stage_name,
+                service_name,
+                service,
+                &service.depends_on,
+            ),
+        });
+    }
+
+    Ok(units)
+}
+
+/// container サービスの systemd unit 名（`{project}-{stage}-{service}.service`）。
+fn service_units(config: &Flow, stage_name: &str, stage: &Stage) -> Vec<String> {
+    stage
+        .services
+        .iter()
+        .filter(|name| {
+            config
+                .services
+                .get(name.as_str())
+                .is_some_and(|s| !s.is_static())
+        })
+        .map(|name| format!("{}.service", unit_base_name(&config.name, stage_name, name)))
+        .collect()
+}
+
+/// `fleet up` の Quadlet 経路。
+pub async fn up(
+    config: &Flow,
+    stage_name: &str,
+    stage: &Stage,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    println!("{}", format!("runtime: quadlet ({stage_name})").cyan());
+
+    let units = build_stage_units(config, stage_name, stage)?;
+
+    if dry_run {
+        println!(
+            "{}",
+            format!("[dry-run] {} 個の Quadlet ユニットを生成:", units.len())
+                .yellow()
+                .bold()
+        );
+        for unit in &units {
+            println!("  • {}", unit.file_name.cyan());
+        }
+        println!(
+            "{}",
+            "[dry-run] 実際の書き込み・systemctl は行われません。".yellow()
+        );
+        return Ok(());
+    }
+
+    let dir = default_quadlet_dir()
+        .ok_or_else(|| anyhow::anyhow!("Quadlet ディレクトリを解決できません（HOME 未設定）"))?;
+
+    println!(
+        "  Quadlet ディレクトリ: {}",
+        dir.display().to_string().cyan()
+    );
+    sync_quadlet_dir(&dir, &config.name, stage_name, &units)?;
+    println!("  {} {} 個のユニットを反映", "✓".green(), units.len());
+
+    // systemd に Quadlet generator を再走させる
+    systemctl_user_daemon_reload()?;
+    println!("  {} systemctl --user daemon-reload", "✓".green());
+
+    // 各 container サービスを起動
+    for unit in service_units(config, stage_name, stage) {
+        systemctl_user_start(&unit)?;
+        println!("  {} {} 起動", "✓".green(), unit.cyan());
+    }
+
+    println!();
+    println!(
+        "{}",
+        "✓ すべてのサービスを起動しました（quadlet）！"
+            .green()
+            .bold()
+    );
+    Ok(())
+}
+
+/// `fleet down` の Quadlet 経路。
+///
+/// `remove` 指定時は Quadlet ファイル自体も削除する（`systemctl` 停止に加えて
+/// snapshot を空にし、daemon-reload で `.service` ユニットを消す）。
+pub async fn down(
+    config: &Flow,
+    stage_name: &str,
+    stage: &Stage,
+    remove: bool,
+) -> anyhow::Result<()> {
+    println!("{}", format!("runtime: quadlet ({stage_name})").cyan());
+
+    // 各 container サービスを停止
+    for unit in service_units(config, stage_name, stage) {
+        match fleetflow_container::quadlet::systemctl_user_stop(&unit) {
+            Ok(()) => println!("  {} {} 停止", "✓".green(), unit.cyan()),
+            Err(e) => println!("  {} {} 停止失敗: {}", "⚠".yellow(), unit.cyan(), e),
+        }
+    }
+
+    if remove {
+        let dir = default_quadlet_dir().ok_or_else(|| {
+            anyhow::anyhow!("Quadlet ディレクトリを解決できません（HOME 未設定）")
+        })?;
+        // 空の束で sync → 同 project/stage の fleetflow ユニットを全削除
+        sync_quadlet_dir(&dir, &config.name, stage_name, &[])?;
+        systemctl_user_daemon_reload()?;
+        println!("  {} Quadlet ファイルを削除", "✓".green());
+    }
+
+    println!();
+    println!("{}", "✓ ステージを停止しました（quadlet）".green().bold());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fleetflow_core::{Service, Stage};
+    use std::collections::HashMap;
+
+    fn flow_with(services: Vec<(&str, Service)>, stage_services: Vec<&str>) -> (Flow, Stage) {
+        let mut svc_map = HashMap::new();
+        for (name, svc) in services {
+            svc_map.insert(name.to_string(), svc);
+        }
+        let stage = Stage {
+            services: stage_services.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        let mut stages = HashMap::new();
+        stages.insert("live".to_string(), stage.clone());
+        let flow = Flow {
+            name: "myapp".to_string(),
+            services: svc_map,
+            stages,
+            providers: HashMap::new(),
+            servers: HashMap::new(),
+            registry: None,
+            variables: HashMap::new(),
+            tenant: None,
+        };
+        (flow, stage)
+    }
+
+    fn container_service() -> Service {
+        Service {
+            image: Some("postgres:16".to_string()),
+            ..Service::default()
+        }
+    }
+
+    #[test]
+    fn build_stage_units_emits_network_plus_containers() {
+        let (flow, stage) = flow_with(
+            vec![("db", container_service()), ("web", container_service())],
+            vec!["db", "web"],
+        );
+        let units = build_stage_units(&flow, "live", &stage).unwrap();
+        // network 1 + container 2
+        assert_eq!(units.len(), 3);
+        let names: Vec<&str> = units.iter().map(|u| u.file_name.as_str()).collect();
+        assert!(names.contains(&"myapp-live.network"));
+        assert!(names.contains(&"myapp-live-db.container"));
+        assert!(names.contains(&"myapp-live-web.container"));
+    }
+
+    #[test]
+    fn build_stage_units_skips_static_services() {
+        let static_svc = Service {
+            service_type: Some(fleetflow_core::ServiceType::Static),
+            ..Service::default()
+        };
+        let (flow, stage) = flow_with(
+            vec![("db", container_service()), ("site", static_svc)],
+            vec!["db", "site"],
+        );
+        let units = build_stage_units(&flow, "live", &stage).unwrap();
+        // network 1 + container 1（static は除外）
+        assert_eq!(units.len(), 2);
+        let names: Vec<&str> = units.iter().map(|u| u.file_name.as_str()).collect();
+        assert!(!names.contains(&"myapp-live-site.container"));
+    }
+
+    #[test]
+    fn build_stage_units_errors_on_missing_image() {
+        let (flow, stage) = flow_with(vec![("db", Service::default())], vec!["db"]);
+        assert!(build_stage_units(&flow, "live", &stage).is_err());
+    }
+
+    #[test]
+    fn service_units_returns_systemd_service_names() {
+        let (flow, stage) = flow_with(vec![("db", container_service())], vec!["db"]);
+        assert_eq!(
+            service_units(&flow, "live", &stage),
+            vec!["myapp-live-db.service"]
+        );
+    }
+}

--- a/crates/fleetflow/src/commands/up.rs
+++ b/crates/fleetflow/src/commands/up.rs
@@ -216,6 +216,17 @@ pub async fn handle(
         )
     })?;
 
+    // WS2: backend が Quadlet/Compose なら専用経路へ分岐
+    match stage_config.backend {
+        fleetflow_core::Backend::Docker => {}
+        fleetflow_core::Backend::Quadlet => {
+            return crate::commands::quadlet::up(config, &stage_name, stage_config, dry_run).await;
+        }
+        fleetflow_core::Backend::Compose => {
+            anyhow::bail!("backend \"compose\" は未実装です（epic WS4）");
+        }
+    }
+
     // dry-run モードの場合は実行計画を表示して終了
     if dry_run {
         return print_dry_run_plan(config, &stage_name, stage_config);


### PR DESCRIPTION
## 概要

Podman+Quadlet 追従 epic（`mem_1CbD3b6j1s3pxQ1TGvaXtv`）の **WS2 Stage 2c**。`fleet up` / `fleet down` が stage の backend 宣言に応じて Quadlet 経路に分岐する。

## Runtime → Backend リネーム

`Runtime` enum を `Backend` にリネーム（field `runtime`→`backend`、KDL キーワード `runtime`→`backend`）。

**理由**: Quadlet は Podman の systemd 統合方式であって「runtime」ではない。`Docker`（エンジン）/ `Quadlet`（Podman の駆動方式）/ `Compose`（フォーマット）はカテゴリが揃わず、`Runtime` という名前は誤解を招く。「fleetflow がどの方式でコンテナを動かすか = backend」という framing に統一（epic の "Backend trait" 用語とも一致）。

```kdl
stage "live" {
    backend "quadlet"
    service "web"
}
```

## fleet up / down の Quadlet 配線

`commands/quadlet.rs` を新設。`up.rs` / `down.rs` が stage の `backend` で分岐：

| backend | 経路 |
|---------|------|
| `Docker` | 従来の bollard 経路 |
| `Quadlet` | `commands::quadlet::{up,down}` |
| `Compose` | 未実装エラー（WS4）|

quadlet 経路は #189 生成器 + #191 適用層を組み合わせる：
- `build_stage_units`（**純粋関数**）— Flow+Stage → `QuadletUnit` 束（`.network` + container ごとの `.container`、静的サイトは除外）
- `up` — units 生成 → `sync_quadlet_dir` → `daemon-reload` → 各 `start`
- `down` — 各 `stop`、`--remove` 時は Quadlet ファイルも削除
- `systemctl_user_stop` を `fleetflow-container` に追加

## スコープ

quadlet 経路は **`fleet up` をホスト上で実行する前提（CLI-local）**。クラウドの CP→agent 経由デプロイは WS3。`Backend` trait は作らない — backend dispatch は `match` で足り、実働 backend が増えるまで trait 抽象は YAGNI（CLAUDE.md「不要な抽象化を避ける」）。

## テスト

- backend パース 3 件（quadlet / 既定 docker / 不正値エラー）
- `build_stage_units` 4 件（network+container / static 除外 / image 欠落エラー / service_units）

`cargo test` グリーン、clippy / fmt クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)