### PR TITLE
feat(agent): fleet-agent が Quadlet backend の deploy に対応 (WS3)

### DIFF
--- a/crates/fleet-agent/Cargo.toml
+++ b/crates/fleet-agent/Cargo.toml
@@ -43,6 +43,8 @@ fleetflow-build.workspace = true
 # kdl-based deploy (DeployEngine + DeployRequest)
 # CP の deploy.execute が server 宣言を読んで agent にリレーする path で必要 (FSC-34)
 fleetflow-container.workspace = true
+# stage.backend (Backend enum) の参照 — WS3 で deploy 経路を backend で分岐
+fleetflow-core.workspace = true
 
 # CLI
 clap.workspace = true

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -327,6 +327,50 @@ async fn handle_deploy_kdl(
         }
     };
 
+    // WS3: stage の backend が Quadlet なら bollard を使わず Quadlet 適用に分岐。
+    // agent は CLI (commands/quadlet.rs) と同じ apply_stage を呼ぶ。
+    if let Some(stage) = deploy_request.flow.stages.get(&deploy_request.stage_name) {
+        match stage.backend {
+            fleetflow_core::Backend::Quadlet => {
+                let response = match fleetflow_container::quadlet::apply_stage(
+                    &deploy_request.flow,
+                    &deploy_request.stage_name,
+                    stage,
+                ) {
+                    Ok(outcome) => json!({
+                        "status": "success",
+                        "log": format!(
+                            "quadlet: {} units 反映, {} services 起動",
+                            outcome.units_written,
+                            outcome.services_started.len()
+                        ),
+                        "services_deployed": outcome.services_started,
+                    }),
+                    Err(e) => json!({
+                        "status": "failed",
+                        "error": format!("quadlet 適用失敗: {}", e),
+                    }),
+                };
+                send_command_result(channel, request_id, response).await?;
+                return Ok(());
+            }
+            fleetflow_core::Backend::Compose => {
+                send_command_result(
+                    channel,
+                    request_id,
+                    json!({
+                        "status": "failed",
+                        "error": "backend \"compose\" は未実装です（epic WS4）",
+                    }),
+                )
+                .await?;
+                return Ok(());
+            }
+            // Docker は以下の従来 bollard 経路へ
+            fleetflow_core::Backend::Docker => {}
+        }
+    }
+
     // local docker daemon (= worker の dockerd) に bollard 接続
     let docker = match bollard::Docker::connect_with_local_defaults() {
         Ok(d) => d,

--- a/crates/fleetflow-container/src/quadlet.rs
+++ b/crates/fleetflow-container/src/quadlet.rs
@@ -19,7 +19,7 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
-use fleetflow_core::{Protocol, RestartPolicy, Service};
+use fleetflow_core::{Flow, Protocol, RestartPolicy, Service, Stage};
 
 /// `{project}-{stage}-{service}` 形式の正準名を組み立てる。
 ///
@@ -289,6 +289,112 @@ fn run_systemctl_user(args: &[&str]) -> io::Result<()> {
     }
 }
 
+// ─────────────────────────────────────────────
+// ステージ適用（WS2 Stage 2c / WS3）— CLI・agent 共用の orchestration
+// ─────────────────────────────────────────────
+
+/// stage の全 container サービスから Quadlet ユニット束を組み立てる（純粋関数）。
+///
+/// `.network` 1 つ + container サービスごとの `.container`。静的サイト
+/// （`type "static"`）は Quadlet 対象外なのでスキップする。
+pub fn build_stage_units(
+    config: &Flow,
+    stage_name: &str,
+    stage: &Stage,
+) -> anyhow::Result<Vec<QuadletUnit>> {
+    let project = &config.name;
+    let mut units = vec![QuadletUnit {
+        file_name: network_file_name(project, stage_name),
+        content: generate_network_unit(project, stage_name),
+    }];
+
+    for service_name in &stage.services {
+        let service = config
+            .services
+            .get(service_name)
+            .ok_or_else(|| anyhow::anyhow!("サービス '{}' の定義が見つかりません", service_name))?;
+
+        // 静的サイトはコンテナではないため Quadlet 対象外
+        if service.is_static() {
+            continue;
+        }
+        if service.image.is_none() {
+            anyhow::bail!("サービス '{}' に image が指定されていません", service_name);
+        }
+
+        units.push(QuadletUnit {
+            file_name: container_file_name(project, stage_name, service_name),
+            content: generate_container_unit(
+                project,
+                stage_name,
+                service_name,
+                service,
+                &service.depends_on,
+            ),
+        });
+    }
+
+    Ok(units)
+}
+
+/// container サービスの systemd unit 名（`{project}-{stage}-{service}.service`）。
+pub fn service_units(config: &Flow, stage_name: &str, stage: &Stage) -> Vec<String> {
+    stage
+        .services
+        .iter()
+        .filter(|name| {
+            config
+                .services
+                .get(name.as_str())
+                .is_some_and(|s| !s.is_static())
+        })
+        .map(|name| format!("{}.service", unit_base_name(&config.name, stage_name, name)))
+        .collect()
+}
+
+/// `apply_stage` の結果。
+#[derive(Debug, Clone)]
+pub struct QuadletApplyOutcome {
+    /// disk に書き出したユニットファイル数。
+    pub units_written: usize,
+    /// `systemctl --user start` した service unit 名。
+    pub services_started: Vec<String>,
+}
+
+/// stage を Quadlet で実体化する — CLI（`fleet up`）と agent（WS3）の共用経路。
+///
+/// 1. KDL からユニット束を生成（`build_stage_units`）
+/// 2. `~/.config/containers/systemd/` に snapshot 反映（`sync_quadlet_dir`）
+/// 3. `systemctl --user daemon-reload` で `.service` を再生成
+/// 4. 各 container サービスを `systemctl --user start`
+///
+/// 注: `systemctl --user` は呼び出しプロセスのユーザーセッションに作用する。
+/// rootless Quadlet のため、呼び出し元（CLI なら実行ユーザー、agent なら
+/// agent プロセス）が対象の rootless ユーザーである必要がある（provisioning は WS5）。
+pub fn apply_stage(
+    config: &Flow,
+    stage_name: &str,
+    stage: &Stage,
+) -> anyhow::Result<QuadletApplyOutcome> {
+    let units = build_stage_units(config, stage_name, stage)?;
+    let dir = default_quadlet_dir()
+        .ok_or_else(|| anyhow::anyhow!("Quadlet ディレクトリを解決できません（HOME 未設定）"))?;
+
+    sync_quadlet_dir(&dir, &config.name, stage_name, &units)?;
+    systemctl_user_daemon_reload()?;
+
+    let mut services_started = Vec::new();
+    for unit in service_units(config, stage_name, stage) {
+        systemctl_user_start(&unit)?;
+        services_started.push(unit);
+    }
+
+    Ok(QuadletApplyOutcome {
+        units_written: units.len(),
+        services_started,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -545,5 +651,86 @@ mod tests {
         assert!(!nested.exists());
         sync_quadlet_dir(&nested, "myapp", "live", &[]).unwrap();
         assert!(nested.exists());
+    }
+
+    // ── ステージ適用（WS2 Stage 2c / WS3）──
+
+    fn flow_with(
+        services: Vec<(&str, Service)>,
+        stage_services: Vec<&str>,
+    ) -> (fleetflow_core::Flow, fleetflow_core::Stage) {
+        let mut svc_map = std::collections::HashMap::new();
+        for (name, svc) in services {
+            svc_map.insert(name.to_string(), svc);
+        }
+        let stage = fleetflow_core::Stage {
+            services: stage_services.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        let mut stages = std::collections::HashMap::new();
+        stages.insert("live".to_string(), stage.clone());
+        let flow = fleetflow_core::Flow {
+            name: "myapp".to_string(),
+            services: svc_map,
+            stages,
+            providers: std::collections::HashMap::new(),
+            servers: std::collections::HashMap::new(),
+            registry: None,
+            variables: std::collections::HashMap::new(),
+            tenant: None,
+        };
+        (flow, stage)
+    }
+
+    fn container_service() -> Service {
+        Service {
+            image: Some("postgres:16".to_string()),
+            ..Service::default()
+        }
+    }
+
+    #[test]
+    fn build_stage_units_emits_network_plus_containers() {
+        let (flow, stage) = flow_with(
+            vec![("db", container_service()), ("web", container_service())],
+            vec!["db", "web"],
+        );
+        let units = build_stage_units(&flow, "live", &stage).unwrap();
+        assert_eq!(units.len(), 3); // network 1 + container 2
+        let names: Vec<&str> = units.iter().map(|u| u.file_name.as_str()).collect();
+        assert!(names.contains(&"myapp-live.network"));
+        assert!(names.contains(&"myapp-live-db.container"));
+        assert!(names.contains(&"myapp-live-web.container"));
+    }
+
+    #[test]
+    fn build_stage_units_skips_static_services() {
+        let static_svc = Service {
+            service_type: Some(fleetflow_core::ServiceType::Static),
+            ..Service::default()
+        };
+        let (flow, stage) = flow_with(
+            vec![("db", container_service()), ("site", static_svc)],
+            vec!["db", "site"],
+        );
+        let units = build_stage_units(&flow, "live", &stage).unwrap();
+        assert_eq!(units.len(), 2); // network 1 + container 1（static 除外）
+        let names: Vec<&str> = units.iter().map(|u| u.file_name.as_str()).collect();
+        assert!(!names.contains(&"myapp-live-site.container"));
+    }
+
+    #[test]
+    fn build_stage_units_errors_on_missing_image() {
+        let (flow, stage) = flow_with(vec![("db", Service::default())], vec!["db"]);
+        assert!(build_stage_units(&flow, "live", &stage).is_err());
+    }
+
+    #[test]
+    fn service_units_returns_systemd_service_names() {
+        let (flow, stage) = flow_with(vec![("db", container_service())], vec!["db"]);
+        assert_eq!(
+            service_units(&flow, "live", &stage),
+            vec!["myapp-live-db.service"]
+        );
     }
 }

--- a/crates/fleetflow/src/commands/quadlet.rs
+++ b/crates/fleetflow/src/commands/quadlet.rs
@@ -1,81 +1,21 @@
-//! Quadlet backend — `fleet up` / `fleet down` の `runtime "quadlet"` 経路
+//! Quadlet backend — `fleet up` / `fleet down` の `backend "quadlet"` 経路
 //!
 //! Podman+Quadlet 追従 epic（creo-memories `mem_1CbD3b6j1s3pxQ1TGvaXtv`）WS2 Stage 2c。
 //!
-//! stage が `runtime "quadlet"` を宣言しているとき、`up.rs` / `down.rs` から
-//! 本モジュールに分岐する。KDL から Quadlet ユニットを生成（`fleetflow-container`
-//! の `quadlet` モジュール）し、ホストの `~/.config/containers/systemd/` に
-//! 反映して `systemctl --user` で起動・停止する。
+//! stage が `backend "quadlet"` を宣言しているとき、`up.rs` / `down.rs` から
+//! 本モジュールに分岐する。実体化のロジックは `fleetflow-container` の
+//! `quadlet` モジュールに集約されており（CLI・agent 共用）、本モジュールは
+//! その薄い presenter（結果を stdout に整形するだけ）。
 //!
 //! 本経路は **`fleet up` をホスト上で実行する**ことを前提とする（CLI-local）。
 //! クラウドの CP→agent 経由デプロイは WS3（agent の Quadlet 役割転換）。
 
 use colored::Colorize;
 use fleetflow_container::quadlet::{
-    QuadletUnit, container_file_name, default_quadlet_dir, generate_container_unit,
-    generate_network_unit, network_file_name, sync_quadlet_dir, systemctl_user_daemon_reload,
-    systemctl_user_start, unit_base_name,
+    apply_stage, build_stage_units, default_quadlet_dir, service_units, sync_quadlet_dir,
+    systemctl_user_daemon_reload, systemctl_user_stop,
 };
 use fleetflow_core::{Flow, Stage};
-
-/// stage の全 container サービスから Quadlet ユニット束を組み立てる（純粋関数）。
-///
-/// `.network` 1 つ + container サービスごとの `.container`。静的サイト
-/// （`type "static"`）は Quadlet 対象外なのでスキップする。
-pub fn build_stage_units(
-    config: &Flow,
-    stage_name: &str,
-    stage: &Stage,
-) -> anyhow::Result<Vec<QuadletUnit>> {
-    let project = &config.name;
-    let mut units = vec![QuadletUnit {
-        file_name: network_file_name(project, stage_name),
-        content: generate_network_unit(project, stage_name),
-    }];
-
-    for service_name in &stage.services {
-        let service = config
-            .services
-            .get(service_name)
-            .ok_or_else(|| anyhow::anyhow!("サービス '{}' の定義が見つかりません", service_name))?;
-
-        // 静的サイトはコンテナではないため Quadlet 対象外
-        if service.is_static() {
-            continue;
-        }
-        if service.image.is_none() {
-            anyhow::bail!("サービス '{}' に image が指定されていません", service_name);
-        }
-
-        units.push(QuadletUnit {
-            file_name: container_file_name(project, stage_name, service_name),
-            content: generate_container_unit(
-                project,
-                stage_name,
-                service_name,
-                service,
-                &service.depends_on,
-            ),
-        });
-    }
-
-    Ok(units)
-}
-
-/// container サービスの systemd unit 名（`{project}-{stage}-{service}.service`）。
-fn service_units(config: &Flow, stage_name: &str, stage: &Stage) -> Vec<String> {
-    stage
-        .services
-        .iter()
-        .filter(|name| {
-            config
-                .services
-                .get(name.as_str())
-                .is_some_and(|s| !s.is_static())
-        })
-        .map(|name| format!("{}.service", unit_base_name(&config.name, stage_name, name)))
-        .collect()
-}
 
 /// `fleet up` の Quadlet 経路。
 pub async fn up(
@@ -84,11 +24,10 @@ pub async fn up(
     stage: &Stage,
     dry_run: bool,
 ) -> anyhow::Result<()> {
-    println!("{}", format!("runtime: quadlet ({stage_name})").cyan());
-
-    let units = build_stage_units(config, stage_name, stage)?;
+    println!("{}", format!("backend: quadlet ({stage_name})").cyan());
 
     if dry_run {
+        let units = build_stage_units(config, stage_name, stage)?;
         println!(
             "{}",
             format!("[dry-run] {} 個の Quadlet ユニットを生成:", units.len())
@@ -105,23 +44,13 @@ pub async fn up(
         return Ok(());
     }
 
-    let dir = default_quadlet_dir()
-        .ok_or_else(|| anyhow::anyhow!("Quadlet ディレクトリを解決できません（HOME 未設定）"))?;
-
+    let outcome = apply_stage(config, stage_name, stage)?;
     println!(
-        "  Quadlet ディレクトリ: {}",
-        dir.display().to_string().cyan()
+        "  {} {} 個のユニットを反映 + daemon-reload",
+        "✓".green(),
+        outcome.units_written
     );
-    sync_quadlet_dir(&dir, &config.name, stage_name, &units)?;
-    println!("  {} {} 個のユニットを反映", "✓".green(), units.len());
-
-    // systemd に Quadlet generator を再走させる
-    systemctl_user_daemon_reload()?;
-    println!("  {} systemctl --user daemon-reload", "✓".green());
-
-    // 各 container サービスを起動
-    for unit in service_units(config, stage_name, stage) {
-        systemctl_user_start(&unit)?;
+    for unit in &outcome.services_started {
         println!("  {} {} 起動", "✓".green(), unit.cyan());
     }
 
@@ -145,11 +74,11 @@ pub async fn down(
     stage: &Stage,
     remove: bool,
 ) -> anyhow::Result<()> {
-    println!("{}", format!("runtime: quadlet ({stage_name})").cyan());
+    println!("{}", format!("backend: quadlet ({stage_name})").cyan());
 
     // 各 container サービスを停止
     for unit in service_units(config, stage_name, stage) {
-        match fleetflow_container::quadlet::systemctl_user_stop(&unit) {
+        match systemctl_user_stop(&unit) {
             Ok(()) => println!("  {} {} 停止", "✓".green(), unit.cyan()),
             Err(e) => println!("  {} {} 停止失敗: {}", "⚠".yellow(), unit.cyan(), e),
         }
@@ -168,89 +97,4 @@ pub async fn down(
     println!();
     println!("{}", "✓ ステージを停止しました（quadlet）".green().bold());
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fleetflow_core::{Service, Stage};
-    use std::collections::HashMap;
-
-    fn flow_with(services: Vec<(&str, Service)>, stage_services: Vec<&str>) -> (Flow, Stage) {
-        let mut svc_map = HashMap::new();
-        for (name, svc) in services {
-            svc_map.insert(name.to_string(), svc);
-        }
-        let stage = Stage {
-            services: stage_services.iter().map(|s| s.to_string()).collect(),
-            ..Default::default()
-        };
-        let mut stages = HashMap::new();
-        stages.insert("live".to_string(), stage.clone());
-        let flow = Flow {
-            name: "myapp".to_string(),
-            services: svc_map,
-            stages,
-            providers: HashMap::new(),
-            servers: HashMap::new(),
-            registry: None,
-            variables: HashMap::new(),
-            tenant: None,
-        };
-        (flow, stage)
-    }
-
-    fn container_service() -> Service {
-        Service {
-            image: Some("postgres:16".to_string()),
-            ..Service::default()
-        }
-    }
-
-    #[test]
-    fn build_stage_units_emits_network_plus_containers() {
-        let (flow, stage) = flow_with(
-            vec![("db", container_service()), ("web", container_service())],
-            vec!["db", "web"],
-        );
-        let units = build_stage_units(&flow, "live", &stage).unwrap();
-        // network 1 + container 2
-        assert_eq!(units.len(), 3);
-        let names: Vec<&str> = units.iter().map(|u| u.file_name.as_str()).collect();
-        assert!(names.contains(&"myapp-live.network"));
-        assert!(names.contains(&"myapp-live-db.container"));
-        assert!(names.contains(&"myapp-live-web.container"));
-    }
-
-    #[test]
-    fn build_stage_units_skips_static_services() {
-        let static_svc = Service {
-            service_type: Some(fleetflow_core::ServiceType::Static),
-            ..Service::default()
-        };
-        let (flow, stage) = flow_with(
-            vec![("db", container_service()), ("site", static_svc)],
-            vec!["db", "site"],
-        );
-        let units = build_stage_units(&flow, "live", &stage).unwrap();
-        // network 1 + container 1（static は除外）
-        assert_eq!(units.len(), 2);
-        let names: Vec<&str> = units.iter().map(|u| u.file_name.as_str()).collect();
-        assert!(!names.contains(&"myapp-live-site.container"));
-    }
-
-    #[test]
-    fn build_stage_units_errors_on_missing_image() {
-        let (flow, stage) = flow_with(vec![("db", Service::default())], vec!["db"]);
-        assert!(build_stage_units(&flow, "live", &stage).is_err());
-    }
-
-    #[test]
-    fn service_units_returns_systemd_service_names() {
-        let (flow, stage) = flow_with(vec![("db", container_service())], vec!["db"]);
-        assert_eq!(
-            service_units(&flow, "live", &stage),
-            vec!["myapp-live-db.service"]
-        );
-    }
 }


### PR DESCRIPTION
## 概要

Podman+Quadlet 追従 epic（`mem_1CbD3b6j1s3pxQ1TGvaXtv`）の **WS3** — fleet-agent の Quadlet 役割転換。

WS2 Stage 2c で `fleet up` をホスト上で実行した時の Quadlet 経路を作った。WS3 はそれを fleet-agent にやらせる — CP→agent 経由のクラウドデプロイで agent が Quadlet を適用する。

## 共有 crate への集約

`build_stage_units` / `service_units` を CLI crate（`commands/quadlet.rs`）から `fleetflow-container::quadlet` に移動（agent も使うため）。さらに「build → sync → daemon-reload → start」を `apply_stage` に集約：

- `apply_stage(flow, stage_name, stage) -> QuadletApplyOutcome`
- CLI・agent の両方が共用、各々は薄い presenter

## agent 側

`handle_deploy_kdl` が stage の `backend` で分岐：

| backend | 経路 |
|---------|------|
| `Quadlet` | `apply_stage`（bollard 不使用）|
| `Compose` | 未実装エラー（WS4）|
| `Docker` | 従来の `DeployEngine` + bollard |

CP↔agent のコマンド応答プロトコル（WS0 で修正済）と `DeployRequest`（Flow + stage）はそのまま再利用 — WS3 は「受信済みの Flow を bollard でなく Quadlet で実体化する」差し替え。

## 既知の前提（WS5 で対応）

`systemctl --user` は呼び出しプロセスのユーザーセッションに作用する。agent が rootless Quadlet を適用するには **agent プロセスが対象の rootless ユーザーである必要がある**。agent を rootless ユーザーで動かす provisioning は WS5（`provision-worker-base.sh` + agent の systemd unit）。

## テスト

`build_stage_units` 系 4 件を `fleetflow-container` に移設（関数の移動に追従）。`cargo test` グリーン、clippy / fmt クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)