### PR TITLE
feat(cp,agent,cli,mcp): MeshCa private-CA で QUIC trust を構成

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,12 @@ kdl = "6"
 # crates.io 公開命名規則 (club- prefix) — 2026-05-15 移行、 git dep → crates.io dep
 # 旧名 `unison` は RobertWHurst/unison (2018-) と衝突、 旧名 `unison-kdl` も同様に
 # 衝突回避で club- prefix を採用 (chronista-club ecosystem 標準)。
-# v1.0.0-rc.1: 1.0 リリース候補。 fleetflow は higher-level ProtocolClient/ProtocolServer 利用。
+# v1.0.0-rc.3: 1.0 リリース候補。 fleetflow は higher-level ProtocolClient/ProtocolServer +
+# MeshCa private-CA primitive を利用。
 club-kdl = "0.8"
-club-unison = "1.0.0-rc.1"
+club-unison = "1.0.0-rc.3"
+# CA cert PEM のパース（client が TrustAnchors::Custom を構成するため）。unison と同版。
+rustls-pemfile = "2.2"
 
 # Template engine
 tera = "1"

--- a/crates/fleet-agent/Cargo.toml
+++ b/crates/fleet-agent/Cargo.toml
@@ -33,6 +33,9 @@ serde_json.workspace = true
 # Unison Protocol (QUIC)
 club-unison.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile.workspace = true
+# CP の CA 証明書パス解決（~/.config/fleetflow/cp-ca-cert.pem）
+dirs.workspace = true
 
 # Docker API
 bollard.workspace = true

--- a/crates/fleet-agent/src/agent.rs
+++ b/crates/fleet-agent/src/agent.rs
@@ -1,6 +1,7 @@
 //! Agent コアループ — CP 接続 + コマンド受信 + ハートビート
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -9,6 +10,8 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 use unison::network::channel::UnisonChannel;
 use unison::network::client::ProtocolClient;
+use unison::network::quic::QuicClient;
+use unison::network::trust::TrustAnchors;
 
 use crate::deploy;
 use crate::heartbeat;
@@ -41,9 +44,48 @@ pub async fn run(config: AgentConfig) -> Result<()> {
     }
 }
 
+/// CP の CA 証明書ファイルのパス。
+///
+/// `FLEETFLOW_CP_CA_CERT` env が優先、無ければ
+/// `~/.config/fleetflow/cp-ca-cert.pem`（OS 依存）。provisioning script で配置する。
+fn ca_cert_path() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("FLEETFLOW_CP_CA_CERT") {
+        return Ok(PathBuf::from(p));
+    }
+    Ok(dirs::config_dir()
+        .context("設定ディレクトリが見つかりません")?
+        .join("fleetflow/cp-ca-cert.pem"))
+}
+
+/// CP の MeshCa CA cert を pin した `ProtocolClient` を構築する。
+///
+/// CP が配布する公開 CA cert を `TrustAnchors::Custom` に入れる。rustls が
+/// CP の server cert を CA 署名 chain として検証する（MITM 耐性）。
+fn build_cp_client() -> Result<ProtocolClient> {
+    let ca_path = ca_cert_path()?;
+    let ca_pem = std::fs::read(&ca_path).with_context(|| {
+        format!(
+            "CP の CA 証明書が見つかりません: {}\n  \
+             provisioning で cp-ca-cert.pem を配置してください \
+             (または FLEETFLOW_CP_CA_CERT で指定)。",
+            ca_path.display()
+        )
+    })?;
+    let mut rd: &[u8] = &ca_pem;
+    let certs = rustls_pemfile::certs(&mut rd)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("CA 証明書 PEM のパース失敗")?;
+    anyhow::ensure!(!certs.is_empty(), "CA 証明書 PEM に証明書がありません");
+    let transport = QuicClient::builder()
+        .trust_anchors(TrustAnchors::Custom(certs))
+        .build()
+        .context("QuicClient の構築失敗")?;
+    Ok(ProtocolClient::new(transport))
+}
+
 /// 1回の CP 接続セッション
 async fn run_session(config: &AgentConfig) -> Result<()> {
-    let client = Arc::new(ProtocolClient::new_default().context("ProtocolClient 作成失敗")?);
+    let client = Arc::new(build_cp_client().context("ProtocolClient 作成失敗")?);
 
     client
         .connect(&config.cp_endpoint)

--- a/crates/fleetflow-controlplane/Cargo.toml
+++ b/crates/fleetflow-controlplane/Cargo.toml
@@ -47,6 +47,7 @@ tracing.workspace = true
 
 # Utils
 chrono.workspace = true
+dirs.workspace = true
 aes-gcm.workspace = true
 base64.workspace = true
 rand = "0.8"

--- a/crates/fleetflow-controlplane/src/cert.rs
+++ b/crates/fleetflow-controlplane/src/cert.rs
@@ -1,0 +1,134 @@
+//! Control Plane の TLS trust マテリアル — club-unison `MeshCa`（private-CA）。
+//!
+//! CP↔agent / CLI↔CP / MCP↔CP の QUIC trust を private-CA で構成する。CP は CA を
+//! 初回に生成して永続化し、起動ごとに自身の server cert を CA から発行する。
+//! CA cert（公開部分）はクライアントに配布され、クライアントは
+//! `TrustAnchors::Custom([ca_cert])` で CA を信頼 → rustls が leaf を chain 検証する。
+//!
+//! trust モデル決定: creo-memories `mem_1CbHWGhygnjy5D8bMa1efe`。
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::info;
+use unison::network::cert::CertSource;
+use unison::network::mesh::MeshCa;
+
+/// CP の設定ディレクトリ（`~/.config/fleetflow` 相当、OS 依存）。
+fn config_dir() -> Result<PathBuf> {
+    Ok(dirs::config_dir()
+        .context("設定ディレクトリが見つかりません")?
+        .join("fleetflow"))
+}
+
+/// CA cert / key の永続化パス（`cp-ca-cert.pem` / `cp-ca-key.pem`）。
+///
+/// `cp-ca-cert.pem` は公開部分 — クライアント（agent/CLI/MCP）への配布対象。
+/// `cp-ca-key.pem` は mesh 全体の cert を発行できる最重要 secret。
+pub fn mesh_ca_paths() -> Result<(PathBuf, PathBuf)> {
+    let dir = config_dir()?;
+    Ok((dir.join("cp-ca-cert.pem"), dir.join("cp-ca-key.pem")))
+}
+
+/// MeshCa を取得する — 永続化済みならロード、無ければ生成して永続化する。
+///
+/// CA key ファイルは 0600（Unix）で書き出す。
+pub fn ensure_mesh_ca() -> Result<MeshCa> {
+    let (cert_path, key_path) = mesh_ca_paths()?;
+    load_or_generate_ca(&cert_path, &key_path)
+}
+
+/// 指定パスから MeshCa をロード、両ファイルが揃っていなければ生成して永続化する。
+fn load_or_generate_ca(cert_path: &Path, key_path: &Path) -> Result<MeshCa> {
+    if cert_path.exists() && key_path.exists() {
+        let cert_pem = std::fs::read_to_string(cert_path)
+            .with_context(|| format!("CA cert 読み込み失敗: {}", cert_path.display()))?;
+        let key_pem = std::fs::read_to_string(key_path)
+            .with_context(|| format!("CA key 読み込み失敗: {}", key_path.display()))?;
+        let ca = MeshCa::from_pem(&cert_pem, &key_pem).context("MeshCa の復元失敗")?;
+        info!(cert = %cert_path.display(), "既存の MeshCa をロード");
+        return Ok(ca);
+    }
+
+    // 初回 — 生成して永続化
+    let ca = MeshCa::generate().context("MeshCa の生成失敗")?;
+    let (cert_pem, key_pem) = ca.to_pem();
+
+    if let Some(parent) = cert_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("設定ディレクトリ作成失敗: {}", parent.display()))?;
+    }
+    std::fs::write(cert_path, cert_pem.as_bytes())
+        .with_context(|| format!("CA cert 書き込み失敗: {}", cert_path.display()))?;
+    write_secret(key_path, &key_pem)?;
+
+    info!(
+        cert = %cert_path.display(),
+        key = %key_path.display(),
+        "MeshCa を新規生成・永続化（CA key は最重要 secret）"
+    );
+    Ok(ca)
+}
+
+/// CP 自身の QUIC server cert を MeshCa から発行する。
+///
+/// `sans` はクライアントが接続に使うホスト名・IP（`cp.fleetstage.cloud` /
+/// Tailscale IP / `localhost` 等）。rustls の SAN 検証に一致する必要がある。
+pub fn issue_server_cert(ca: &MeshCa, sans: &[String]) -> Result<CertSource> {
+    ca.issue(sans.iter().cloned())
+        .context("CP server cert の発行失敗")
+}
+
+/// secret ファイルを 0600（Unix）で書き出す。
+fn write_secret(path: &Path, content: &str) -> Result<()> {
+    std::fs::write(path, content.as_bytes())
+        .with_context(|| format!("secret 書き込み失敗: {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("secret パーミッション設定失敗: {}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_or_generate_ca_generates_then_reuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert = dir.path().join("ca-cert.pem");
+        let key = dir.path().join("ca-key.pem");
+
+        // 初回 — 生成して永続化
+        load_or_generate_ca(&cert, &key).unwrap();
+        assert!(cert.exists() && key.exists());
+        let cert_pem_1 = std::fs::read_to_string(&cert).unwrap();
+
+        // 2 回目 — 既存をロード（再生成しない）
+        load_or_generate_ca(&cert, &key).unwrap();
+        let cert_pem_2 = std::fs::read_to_string(&cert).unwrap();
+        assert_eq!(cert_pem_1, cert_pem_2, "既存 CA が再生成された");
+    }
+
+    #[test]
+    fn issue_server_cert_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = load_or_generate_ca(&dir.path().join("c.pem"), &dir.path().join("k.pem")).unwrap();
+        issue_server_cert(&ca, &["localhost".into(), "cp.example.com".into()])
+            .expect("server cert 発行");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ca_key_file_is_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("k.pem");
+        load_or_generate_ca(&dir.path().join("c.pem"), &key).unwrap();
+        let mode = std::fs::metadata(&key).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+}

--- a/crates/fleetflow-controlplane/src/lib.rs
+++ b/crates/fleetflow-controlplane/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent_registry;
 pub mod auth;
+pub mod cert;
 pub mod crypto;
 pub mod db;
 pub mod handlers;

--- a/crates/fleetflow-controlplane/src/server.rs
+++ b/crates/fleetflow-controlplane/src/server.rs
@@ -1,8 +1,11 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use tracing::info;
-use unison::network::server::{ProtocolServer, ServerHandle};
+use unison::network::cert::CertSource;
+use unison::network::quic::QuicServer;
+use unison::network::server::ProtocolServer;
 
 use crate::agent_registry::AgentRegistry;
 use crate::auth::{Auth0Config, Auth0Verifier, AuthProviderKind};
@@ -32,6 +35,11 @@ pub struct ServerConfig {
     pub auth: Option<Auth0Config>,
     /// クラウドプロバイダーのサーバー操作（オプション）
     pub server_provider: Option<ServerProviderKind>,
+    /// CP server cert（MeshCa 発行）の SAN。
+    ///
+    /// クライアントが QUIC 接続に使うホスト名・IP（`cp.fleetstage.cloud` /
+    /// Tailscale IP 等）。rustls の SAN 検証に一致する必要がある。
+    pub cert_sans: Vec<String>,
 }
 
 impl Default for ServerConfig {
@@ -41,6 +49,7 @@ impl Default for ServerConfig {
             db: DbConfig::default(),
             auth: None,
             server_provider: None,
+            cert_sans: vec!["localhost".into(), "::1".into()],
         }
     }
 }
@@ -58,17 +67,19 @@ impl std::fmt::Debug for ServerConfig {
                     .as_ref()
                     .map(|p| p.provider_name().to_string()),
             )
+            .field("cert_sans", &self.cert_sans)
             .finish()
     }
 }
 
 /// Start the Control Plane server.
 ///
-/// 1. Connect to SurrealDB
-/// 2. Initialize Auth0 verifier
-/// 3. Register Unison channels
-/// 4. Start QUIC listener
-pub async fn start(config: ServerConfig) -> Result<(ServerHandle, Arc<AppState>)> {
+/// 1. SurrealDB に接続
+/// 2. Auth0 verifier を初期化
+/// 3. Unison channel を登録
+/// 4. MeshCa をロード/生成し CP server cert を発行
+/// 5. QUIC リスナーを起動
+pub async fn start(config: ServerConfig) -> Result<(CpServerHandle, Arc<AppState>)> {
     // Initialize dependencies
     let db = Database::connect(&config.db).await?;
     let auth = match config.auth {
@@ -97,15 +108,89 @@ pub async fn start(config: ServerConfig) -> Result<(ServerHandle, Arc<AppState>)
     // Register channels
     handlers::register_all(&server, state.clone()).await;
 
-    info!(addr = %config.listen_addr, "Control Plane 起動中");
+    // MeshCa — CA をロード/生成し、CP 自身の QUIC server cert を発行する。
+    let ca = crate::cert::ensure_mesh_ca()?;
+    let cert_source = crate::cert::issue_server_cert(&ca, &config.cert_sans)?;
 
-    // Start listening
-    let handle = server
-        .spawn_listen(&config.listen_addr)
-        .await
-        .context("QUIC リスナー起動失敗")?;
+    info!(
+        addr = %config.listen_addr,
+        sans = ?config.cert_sans,
+        "Control Plane 起動中（MeshCa 発行 cert で QUIC TLS）"
+    );
+
+    let handle = spawn_quic(server, cert_source, &config.listen_addr).await?;
 
     info!(addr = %config.listen_addr, "Control Plane 起動完了");
 
     Ok((handle, state))
+}
+
+/// `QuicServer::builder` で CertSource を注入して QUIC server を spawn する。
+///
+/// unison の `ProtocolServer::spawn_listen` は raw QUIC で CertSource を受け取れず
+/// `CertSource::dev_localhost`（DEV 用）に固定されるため、公開 builder API
+/// `QuicServer::builder().cert_source(...)` を直接使う。
+async fn spawn_quic(
+    server: ProtocolServer,
+    cert_source: CertSource,
+    addr: &str,
+) -> Result<CpServerHandle> {
+    let protocol_server = Arc::new(server);
+    let mut quic_server = QuicServer::builder(Arc::clone(&protocol_server))
+        .cert_source(cert_source)
+        .build();
+    quic_server
+        .bind(addr)
+        .await
+        .with_context(|| format!("QUIC bind 失敗: {addr}"))?;
+    let local_addr = quic_server
+        .local_addr()
+        .context("QUIC server が bind されていません")?;
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let join_handle = tokio::spawn(async move {
+        if let Err(e) = quic_server.start_with_shutdown(shutdown_rx).await {
+            tracing::error!(error = %e, "QUIC server 異常終了");
+        }
+    });
+
+    Ok(CpServerHandle {
+        join_handle,
+        shutdown_tx: Some(shutdown_tx),
+        local_addr,
+    })
+}
+
+/// CP QUIC server のライフサイクルハンドル。
+///
+/// unison の `ServerHandle` はフィールドが private で外部構築できない。
+/// CertSource 注入のため `spawn_listen` でなく `QuicServer::builder` を使う
+/// fleetflow では、同等のハンドルを自前で持つ。
+pub struct CpServerHandle {
+    join_handle: tokio::task::JoinHandle<()>,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    local_addr: SocketAddr,
+}
+
+impl CpServerHandle {
+    /// bind したローカルアドレス。
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// server タスクが終了済みか。
+    pub fn is_finished(&self) -> bool {
+        self.join_handle.is_finished()
+    }
+
+    /// graceful shutdown — shutdown シグナルを送り完了を待つ。
+    pub async fn shutdown(mut self) -> Result<()> {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        self.join_handle
+            .await
+            .context("CP server タスクの join 失敗")?;
+        Ok(())
+    }
 }

--- a/crates/fleetflow-mcp/Cargo.toml
+++ b/crates/fleetflow-mcp/Cargo.toml
@@ -34,6 +34,7 @@ bollard.workspace = true
 # CP integration (v2)
 club-unison.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile.workspace = true
 dirs = "6"
 chrono.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/crates/fleetflow-mcp/src/cp.rs
+++ b/crates/fleetflow-mcp/src/cp.rs
@@ -2,10 +2,14 @@
 //!
 //! CLI 側の cp_client と同じロジックだが、MCP crate 内で自己完結するよう簡略版として実装。
 
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use unison::network::client::ProtocolClient;
+use unison::network::quic::QuicClient;
+use unison::network::trust::TrustAnchors;
 
 /// Dashboard API のベース URL
 const DASHBOARD_BASE: &str = "http://127.0.0.1:32080";
@@ -45,7 +49,7 @@ pub async fn connect() -> Result<(ProtocolClient, Credentials)> {
         anyhow::bail!("認証トークンの有効期限切れ。`fleet login` で再認証してください。");
     }
 
-    let client = ProtocolClient::new_default().context("Unison ProtocolClient 作成失敗")?;
+    let client = build_cp_client().context("Unison ProtocolClient 作成失敗")?;
 
     client
         .connect(&creds.api_endpoint)
@@ -81,6 +85,45 @@ pub async fn request(
     }
 
     Ok(resp)
+}
+
+/// CP の CA 証明書ファイルのパス。
+///
+/// `FLEETFLOW_CP_CA_CERT` env が優先、無ければ
+/// `~/.config/fleetflow/cp-ca-cert.pem`（OS 依存）。
+fn ca_cert_path() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("FLEETFLOW_CP_CA_CERT") {
+        return Ok(PathBuf::from(p));
+    }
+    Ok(dirs::config_dir()
+        .context("設定ディレクトリが見つかりません")?
+        .join("fleetflow/cp-ca-cert.pem"))
+}
+
+/// CP の MeshCa CA cert を pin した `ProtocolClient` を構築する。
+///
+/// CP が配布する公開 CA cert を `TrustAnchors::Custom` に入れる。rustls が
+/// CP の server cert を CA 署名 chain として検証する（MITM 耐性）。
+fn build_cp_client() -> Result<ProtocolClient> {
+    let ca_path = ca_cert_path()?;
+    let ca_pem = std::fs::read(&ca_path).with_context(|| {
+        format!(
+            "CP の CA 証明書が見つかりません: {}\n  \
+             CP 管理者から cp-ca-cert.pem を取得し配置してください \
+             (または FLEETFLOW_CP_CA_CERT で指定)。",
+            ca_path.display()
+        )
+    })?;
+    let mut rd: &[u8] = &ca_pem;
+    let certs = rustls_pemfile::certs(&mut rd)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("CA 証明書 PEM のパース失敗")?;
+    anyhow::ensure!(!certs.is_empty(), "CA 証明書 PEM に証明書がありません");
+    let transport = QuicClient::builder()
+        .trust_anchors(TrustAnchors::Custom(certs))
+        .build()
+        .context("QuicClient の構築失敗")?;
+    Ok(ProtocolClient::new(transport))
 }
 
 /// 共有 HTTP クライアント（コネクションプール再利用）

--- a/crates/fleetflow/Cargo.toml
+++ b/crates/fleetflow/Cargo.toml
@@ -64,6 +64,7 @@ open = "5"
 # Control Plane client
 club-unison.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/fleetflow/src/commands/cp_client.rs
+++ b/crates/fleetflow/src/commands/cp_client.rs
@@ -3,10 +3,14 @@
 //! credentials.json から接続先とトークンを読み込み、
 //! ProtocolClient で CP に接続して channel を開く。
 
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use colored::Colorize;
 use serde_json::Value;
 use unison::network::client::ProtocolClient;
+use unison::network::quic::QuicClient;
+use unison::network::trust::TrustAnchors;
 
 use super::auth::Credentials;
 
@@ -41,7 +45,7 @@ pub async fn connect() -> Result<(ProtocolClient, Credentials)> {
         std::process::exit(1);
     }
 
-    let client = ProtocolClient::new_default().context("Unison ProtocolClient 作成失敗")?;
+    let client = build_cp_client().context("Unison ProtocolClient 作成失敗")?;
 
     client
         .connect(&creds.api_endpoint)
@@ -79,4 +83,43 @@ pub async fn request(
     }
 
     Ok(resp)
+}
+
+/// CP の CA 証明書ファイルのパス。
+///
+/// `FLEETFLOW_CP_CA_CERT` env が優先、無ければ
+/// `~/.config/fleetflow/cp-ca-cert.pem`（OS 依存）。
+fn ca_cert_path() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("FLEETFLOW_CP_CA_CERT") {
+        return Ok(PathBuf::from(p));
+    }
+    Ok(dirs::config_dir()
+        .context("設定ディレクトリが見つかりません")?
+        .join("fleetflow/cp-ca-cert.pem"))
+}
+
+/// CP の MeshCa CA cert を pin した `ProtocolClient` を構築する。
+///
+/// CP が配布する公開 CA cert を `TrustAnchors::Custom` に入れる。rustls が
+/// CP の server cert を CA 署名 chain として検証する（MITM 耐性）。
+fn build_cp_client() -> Result<ProtocolClient> {
+    let ca_path = ca_cert_path()?;
+    let ca_pem = std::fs::read(&ca_path).with_context(|| {
+        format!(
+            "CP の CA 証明書が見つかりません: {}\n  \
+             CP 管理者から cp-ca-cert.pem を取得し配置してください \
+             (または FLEETFLOW_CP_CA_CERT で指定)。",
+            ca_path.display()
+        )
+    })?;
+    let mut rd: &[u8] = &ca_pem;
+    let certs = rustls_pemfile::certs(&mut rd)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("CA 証明書 PEM のパース失敗")?;
+    anyhow::ensure!(!certs.is_empty(), "CA 証明書 PEM に証明書がありません");
+    let transport = QuicClient::builder()
+        .trust_anchors(TrustAnchors::Custom(certs))
+        .build()
+        .context("QuicClient の構築失敗")?;
+    Ok(ProtocolClient::new(transport))
 }

--- a/crates/fleetflowd/src/config.rs
+++ b/crates/fleetflowd/src/config.rs
@@ -102,6 +102,19 @@ pub fn load_config(path: &Path) -> Result<DaemonConfig> {
         config.server.listen_addr = val.to_string();
     }
 
+    // CP server cert（MeshCa 発行）の SAN — env で追加。
+    // FLEETFLOW_CP_CERT_SANS にカンマ区切りで、クライアントが QUIC 接続に使う
+    // ホスト名・IP（cp.fleetstage.cloud / Tailscale IP 等）を列挙する。
+    // rustls の SAN 検証に一致しない接続先は拒否される。
+    if let Ok(sans) = std::env::var("FLEETFLOW_CP_CERT_SANS") {
+        for san in sans.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            let san = san.to_string();
+            if !config.server.cert_sans.contains(&san) {
+                config.server.cert_sans.push(san);
+            }
+        }
+    }
+
     // database ノード
     if let Some(database) = doc.get("database")
         && let Some(children) = database.children()


### PR DESCRIPTION
## 概要

unison rc.1 が `SkipVerification` を loopback 限定に制限したため、CP
（`cp.fleetstage.cloud`、非 loopback）↔ agent/CLI/MCP の QUIC 接続で trust を
確立できず、Podman+Quadlet 移行 epic がブロックされていた。

club-unison **1.0.0-rc.3** の `MeshCa`（private-CA primitive）で trust を構成する。
unison 側の MeshCa は別途 handoff し、club-unison lead が実装・rc.3 リリース済み。

trust モデル決定の経緯: creo-memories `mem_1CbHWGhygnjy5D8bMa1efe`（Council →
ultrathink で TOFU を退け private-CA に確定）。

## CP サーバ側（`fleetflow-controlplane`）

- **`cert.rs` 新設**: `MeshCa` を初回生成して `~/.config/fleetflow/` に永続化
  （`cp-ca-cert.pem` = 公開・クライアント配布用 / `cp-ca-key.pem` = 0600 の最重要 secret）。
  起動ごとに自身の QUIC server cert を CA から `issue` する。
- **`server.rs`**: `ProtocolServer::spawn_listen` は raw QUIC で CertSource を
  注入できず `dev_localhost` に固定されるため、公開 builder API
  `QuicServer::builder().cert_source(...)` を直接使う。unison の `ServerHandle`
  は外部構築不可なので同等の `CpServerHandle` を持つ。
- **`ServerConfig.cert_sans`**: fleetflowd が `FLEETFLOW_CP_CERT_SANS` env で
  クライアント接続先（`cp.fleetstage.cloud` / Tailscale IP 等）を指定。
  rustls の SAN 検証に一致しない接続先は拒否される。

## クライアント側（agent / CLI / MCP）

- `ProtocolClient::new_default()`（= `SkipVerification`）を廃し、配布された
  CA cert を `TrustAnchors::Custom` に入れて `QuicClient` を構築。rustls が
  CP server cert を CA 署名 chain として検証する（MITM 耐性）。
- CA cert パスは `FLEETFLOW_CP_CA_CERT` env 優先、既定
  `~/.config/fleetflow/cp-ca-cert.pem`。agent は provisioning で配置。

## 依存

- `club-unison` 1.0.0-rc.1 → **1.0.0-rc.3**（MeshCa 追加版）
- `rustls-pemfile` 追加（client が CA cert PEM をパースするため）

## テスト

- `cert.rs` に 3 件（CA 生成→再利用で再生成しない / server cert 発行 / CA key の 0600）
- `cargo build` / `clippy` / `fmt` / `test --workspace --lib`（全 crate）全 pass

## 運用メモ（follow-up）

CA cert（`cp-ca-cert.pem`）のクライアント配布は運用手順。agent は provisioning
script で配置、CLI/MCP の少数 operator マシンは手動配置（または `FLEETFLOW_CP_CA_CERT`
で指定）。CP デプロイ時に `FLEETFLOW_CP_CERT_SANS` の設定が必須。

🤖 Generated with [Claude Code](https://claude.com/claude-code)