### PR TITLE
feat(cli,cp): fleet cp server delete + register の provider 検証

### DIFF
--- a/crates/fleetflow-controlplane/src/db.rs
+++ b/crates/fleetflow-controlplane/src/db.rs
@@ -818,15 +818,29 @@ impl Database {
         Ok(server)
     }
 
-    /// サーバーを DB から削除
-    pub async fn delete_server(&self, slug: &str) -> Result<()> {
+    /// サーバーを DB から削除（soft-delete、tenant スコープ）
+    ///
+    /// slug は tenant 内ユニークなので `tenant_slug` でスコープする。tenant 非スコープの
+    /// `WHERE slug = $slug` だと同名サーバーが複数 tenant にある場合に巻き添え削除する。
+    /// 対象が存在し soft-delete したら `true`、tenant 不在・該当サーバー無しは `false`。
+    pub async fn delete_server(&self, tenant_slug: &str, slug: &str) -> Result<bool> {
+        // record-link 越しの `tenant.slug` は UPDATE の WHERE では当てにならないため、
+        // tenant の RecordId を解決して `tenant = $id` の直接比較でスコープする。
+        let Some(tenant) = self.get_tenant_by_slug(tenant_slug).await? else {
+            return Ok(false);
+        };
+        let tenant_id = tenant.id.context("tenant レコードに id がない")?;
+
         // D#4 soft-delete: hard DELETE → UPDATE deleted_at で復旧可能 + feedback_no_data_deletion.md 整合
-        self.db
-            .query("UPDATE server SET deleted_at = time::now() WHERE slug = $slug AND deleted_at IS NONE")
+        let mut result = self
+            .db
+            .query("UPDATE server SET deleted_at = time::now() WHERE slug = $slug AND tenant = $tenant AND deleted_at IS NONE RETURN BEFORE")
             .bind(("slug", slug.to_string()))
+            .bind(("tenant", tenant_id))
             .await
             .context("サーバー削除失敗")?;
-        Ok(())
+        let deleted: Vec<Server> = result.take(0)?;
+        Ok(!deleted.is_empty())
     }
 
     // ─────────────────────────────────────────
@@ -1992,6 +2006,85 @@ mod tests {
         let servers = db.list_servers_by_tenant("anycreative").await.unwrap();
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].slug, "vps-01");
+    }
+
+    /// delete_server は tenant スコープ — 同名 slug が複数 tenant にあっても
+    /// 対象 tenant の 1 件だけを soft-delete し、他 tenant を巻き添えにしない。
+    #[tokio::test]
+    async fn test_delete_server_is_tenant_scoped() {
+        let db = Database::connect_memory().await.unwrap();
+
+        let mk_tenant = |slug: &str| Tenant {
+            id: None,
+            slug: slug.into(),
+            name: slug.into(),
+            auth0_org_id: None,
+            plan: "self-hosted".into(),
+            dns_provider: None,
+            dns_domain: None,
+            dns_zone_id: None,
+            dns_api_token_encrypted: None,
+            placement_policy: None,
+            created_at: None,
+            updated_at: None,
+        };
+        let ta = db.create_tenant(&mk_tenant("tenant-a")).await.unwrap();
+        let tb = db.create_tenant(&mk_tenant("tenant-b")).await.unwrap();
+
+        let mk_server = |tenant: RecordId| Server {
+            id: None,
+            tenant,
+            slug: "shared-slug".into(),
+            provider: "manual".into(),
+            plan: None,
+            ssh_host: "10.0.0.1".into(),
+            ssh_user: "root".into(),
+            deploy_path: "/opt/apps".into(),
+            status: "offline".into(),
+            provision_version: None,
+            tool_versions: None,
+            last_heartbeat_at: None,
+            labels: None,
+            capacity: None,
+            allocated: None,
+            scheduling: None,
+            pool_id: None,
+            desired_state: None,
+            purpose: None,
+            owner: None,
+            sakura: None,
+            tailscale: None,
+            dns: None,
+            lifecycle: None,
+            created_at: None,
+            updated_at: None,
+            deleted_at: None,
+        };
+        db.register_server(&mk_server(ta.id.clone().unwrap()))
+            .await
+            .unwrap();
+        db.register_server(&mk_server(tb.id.clone().unwrap()))
+            .await
+            .unwrap();
+
+        // tenant-a の shared-slug を削除 → true
+        assert!(db.delete_server("tenant-a", "shared-slug").await.unwrap());
+
+        // tenant-a からは消え、tenant-b には残る（巻き添えなし）
+        assert!(
+            db.list_servers_by_tenant("tenant-a")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            db.list_servers_by_tenant("tenant-b").await.unwrap().len(),
+            1
+        );
+
+        // 再削除は false（既に deleted）、存在しない slug も false
+        assert!(!db.delete_server("tenant-a", "shared-slug").await.unwrap());
+        assert!(!db.delete_server("tenant-b", "no-such").await.unwrap());
     }
 
     // FSC-26 Phase B-1: Server に labels / capacity / allocated / scheduling を

--- a/crates/fleetflow-controlplane/src/handlers/server.rs
+++ b/crates/fleetflow-controlplane/src/handlers/server.rs
@@ -9,6 +9,13 @@ use unison::network::server::ProtocolServer;
 use crate::model::{Alert, ObservedContainer, Server, ServerStatusUpdate};
 use crate::server::AppState;
 
+/// `server.provider` に許可される正規の値。
+///
+/// register 時に検証し、`sakura`（`sakura-cloud` の typo）等の非正規値が DB に
+/// 入るのを防ぐ。cloud server provider 名は `SakuraProvider::name`（`"sakura-cloud"`）と
+/// 一致させ、クラウド連携のないサーバーは `"manual"` とする。
+const VALID_SERVER_PROVIDERS: &[&str] = &["sakura-cloud", "manual"];
+
 /// `inventory_report` payload の `containers` 配列を `Vec<ObservedContainer>` に
 /// 変換する（純粋関数 — テスト可能）。
 ///
@@ -91,6 +98,24 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                         "register" => {
                             let tenant_slug = payload["tenant_slug"].as_str().unwrap_or_default();
 
+                            // provider を既知値で検証（typo で非正規値が DB に入るのを防ぐ）
+                            let provider =
+                                payload["provider"].as_str().unwrap_or_default();
+                            if !VALID_SERVER_PROVIDERS.contains(&provider) {
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        "register",
+                                        &json!({ "error": format!(
+                                            "未知の provider '{}'。有効な値: {}",
+                                            provider,
+                                            VALID_SERVER_PROVIDERS.join(", ")
+                                        ) }),
+                                    )
+                                    .await?;
+                                continue;
+                            }
+
                             // Resolve tenant
                             let tenant = match state.db.get_tenant_by_slug(tenant_slug).await {
                                 Ok(Some(t)) => t,
@@ -121,7 +146,7 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 id: None,
                                 tenant: tenant.id.unwrap(),
                                 slug: payload["slug"].as_str().unwrap_or_default().into(),
-                                provider: payload["provider"].as_str().unwrap_or_default().into(),
+                                provider: provider.into(),
                                 plan: payload["plan"].as_str().map(String::from),
                                 ssh_host: payload["ssh_host"].as_str().unwrap_or_default().into(),
                                 ssh_user: payload["ssh_user"].as_str().unwrap_or("root").into(),
@@ -496,6 +521,8 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                             }
                         }
                         "delete" => {
+                            let tenant_slug =
+                                payload["tenant_slug"].as_str().unwrap_or_default();
                             let slug = payload["slug"].as_str().unwrap_or_default();
                             // C1: disk 削除は明示的 opt-in (`feedback_disk_deletion_confirm.md`)。
                             // field omit / typo で disk silent destroy を回避するため default false。
@@ -534,14 +561,23 @@ pub async fn register(server: &ProtocolServer, state: Arc<AppState>) {
                                 }
                             }
 
-                            // DB から削除
-                            match state.db.delete_server(slug).await {
-                                Ok(()) => {
+                            // DB から削除（tenant スコープの soft-delete）
+                            match state.db.delete_server(tenant_slug, slug).await {
+                                Ok(true) => {
                                     channel
                                         .send_response(
                                             msg.id,
                                             "delete",
                                             &json!({ "deleted": slug }),
+                                        )
+                                        .await?;
+                                }
+                                Ok(false) => {
+                                    channel
+                                        .send_response(
+                                            msg.id,
+                                            "delete",
+                                            &json!({ "error": "server not found" }),
                                         )
                                         .await?;
                                 }

--- a/crates/fleetflow/src/commands/cp.rs
+++ b/crates/fleetflow/src/commands/cp.rs
@@ -264,6 +264,21 @@ pub async fn handle_server(cmd: &ServerCommands) -> Result<()> {
                 println!("{} {}", "登録完了:".green(), slug.cyan());
             }
         }
+        ServerCommands::Delete { slug } => {
+            println!("{}", "サーバー登録解除".bold());
+
+            let resp = cp_client::request(
+                &client,
+                "server",
+                "delete",
+                json!({ "tenant_slug": tenant_slug, "slug": slug }),
+            )
+            .await?;
+
+            if resp.get("deleted").is_some() {
+                println!("{} {}", "登録解除完了:".green(), slug.cyan());
+            }
+        }
         ServerCommands::Status { slug } => {
             println!("{} {}", "サーバー状態:".bold(), slug.cyan());
             println!();

--- a/crates/fleetflow/src/main.rs
+++ b/crates/fleetflow/src/main.rs
@@ -365,6 +365,11 @@ enum ServerCommands {
         #[arg(long)]
         deploy_path: Option<String>,
     },
+    /// サーバーを CP から登録解除（DB レコードの soft-delete。クラウド実体は削除しない）
+    Delete {
+        /// サーバーのスラッグ
+        slug: String,
+    },
     /// サーバー状態
     Status {
         /// サーバーのスラッグ


### PR DESCRIPTION
## 背景

`fleet cp server` には誤登録したサーバーレコードを消す導線が無く、重複レコードの
cleanup を SurrealDB 直接操作で行う羽目になった。あわせて `server register` が
provider 文字列を無検証で受けるため、`sakura`（`sakura-cloud` の typo）が DB に
混入していた。この 2 点を塞ぐ。

## 変更

### `fleet cp server delete <slug>`

CP からサーバーを登録解除する CLI コマンドを追加。`server` チャネルには delete
メソッドが既に存在したが CLI 導線が無かった。DB レコードの **soft-delete**
（`deleted_at` セット、復旧可能）で、クラウド実体は削除しない。

### `delete_server` の tenant スコープ化

`db.delete_server` は `WHERE slug = $slug` のみで **tenant 非スコープ**だった。
slug は tenant 内ユニークなので、同名サーバーが複数 tenant にあると巻き添え削除
する（実際に `hq` / `anycreative` 両方に `fleet-worker-01` が存在した）。
`(tenant_slug, slug)` 引数に変更し tenant でスコープ、戻り値を `Result<bool>` に
して「該当なし」を呼び出し側へ伝える。

> record-link 越しの `tenant.slug` は UPDATE の WHERE では当てにならない
> （SELECT では効くが UPDATE では 0 件マッチ — テストで発覚）。tenant の
> `RecordId` を解決し `tenant = $id` の直接比較でスコープする。

### `register` の provider 検証

CP の register ハンドラで provider を `VALID_SERVER_PROVIDERS`
（`sakura-cloud` / `manual`）に対し検証し、未知値は弾く。MCP / Web 経由の
register も同じハンドラを通るので一括で守られる。

## テスト

- `db.rs` に `test_delete_server_is_tenant_scoped` を追加 — 同名 slug が複数
  tenant にあっても対象 tenant の 1 件だけ削除し、他 tenant を巻き添えにしない。
  再削除・存在しない slug は `false`。
- `cargo build` / `clippy` / `fmt` / `test`（controlplane 54 件 + CLI）全 pass。

## 補足（follow-up）

- リポジトリ root の `history.txt` は `surreal sql` の REPL 履歴で、git 追跡
  すべきでない（`.gitignore` + `git rm --cached` 推奨）。本 PR では未対応。
- CP 側 delete ハンドラの新挙動（tenant スコープ・provider 検証）を本番反映
  するには fleetflowd の再デプロイが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)