### PR TITLE
feat(provisioning): 非対話 ssh で linuxbrew/mise PATH を根治 (v5)

### DIFF
--- a/crates/fleetflow-cloud-sakura/src/startup_scripts.rs
+++ b/crates/fleetflow-cloud-sakura/src/startup_scripts.rs
@@ -5,7 +5,11 @@
 
 /// mise installer script
 /// Installs mise (task runner + tool version manager)
-pub const MISE_SETUP: &str = r#"#!/bin/bash
+//
+// raw string delimiter は `r##"..."##` を使用。
+// 内部 bash の `"# FLEETFLOW: ..."` (= double-quote 内に # を持つ comment string) が
+// `r#"..."#` の終端 `"#` と衝突するため delimiter を 1 段増やしている。
+pub const MISE_SETUP: &str = r##"#!/bin/bash
 # @sacloud-name "fleetflow-mise-setup"
 # @sacloud-once
 # @sacloud-desc FleetFlow: mise (タスクランナー + ツールバージョン管理) をインストール
@@ -14,25 +18,61 @@ set -e
 
 echo "=== FleetFlow: mise セットアップ ==="
 
+# 非対話 ssh / login shell の両経路で PATH を通すヘルパ。
+# Debian/Ubuntu の .bashrc は冒頭に `case $- in *i*) ;; *) return;; esac` を持つため、
+# 末尾 append された eval は `ssh host 'cmd'` 経由で実行されない (PATH が通らない)。
+# return ガードの直前に marker 付きブロックを idempotent 挿入する。
+write_noninteractive_path() {
+    local target="$1"
+    [ -f "$target" ] || return 0
+    local begin="# FLEETFLOW: non-interactive PATH (auto-managed, do not edit)"
+    local end="# FLEETFLOW: end non-interactive PATH"
+    if grep -qF "$begin" "$target"; then
+        return 0
+    fi
+    local block="${begin}
+if [ -x /usr/local/bin/mise ]; then
+  eval \"\$(/usr/local/bin/mise activate bash)\"
+elif [ -x \"\$HOME/.local/bin/mise\" ]; then
+  eval \"\$(\$HOME/.local/bin/mise activate bash)\"
+fi
+${end}
+"
+    if grep -q '^case \$- in' "$target"; then
+        awk -v block="$block" '
+          !done && /^case \$- in/ { printf "%s", block; done=1 }
+          { print }
+        ' "$target" > "${target}.tmp" && mv "${target}.tmp" "$target"
+    else
+        { printf '%s\n' "$block"; cat "$target"; } > "${target}.tmp" && mv "${target}.tmp" "$target"
+    fi
+}
+
 # Install mise
 if ! command -v mise &> /dev/null; then
     echo ">>> mise をインストール中..."
     curl -fsSL https://mise.run | sh
 
-    # Add to bashrc for all users
-    echo 'eval "$($HOME/.local/bin/mise activate bash)"' >> /etc/skel/.bashrc
-
-    # Add for root
-    echo 'eval "$($HOME/.local/bin/mise activate bash)"' >> /root/.bashrc
-
-    # Add for ubuntu user if exists
-    if id "ubuntu" &>/dev/null; then
-        sudo -u ubuntu bash -c 'echo "eval \"\$(\$HOME/.local/bin/mise activate bash)\"" >> ~/.bashrc'
+    # /usr/local/bin にシンボリックリンク (全ユーザー共通参照、 helper の前提)
+    if [ -f /root/.local/bin/mise ] && [ ! -f /usr/local/bin/mise ]; then
+        ln -s /root/.local/bin/mise /usr/local/bin/mise
     fi
 fi
 
+# 非対話 ssh で素のワンライナーが通るよう /etc/skel + 既存ユーザーに注入
+write_noninteractive_path /etc/skel/.bashrc
+write_noninteractive_path /root/.bashrc
+[ -d /home/ubuntu ] && write_noninteractive_path /home/ubuntu/.bashrc
+
+# login shell 経路の二重保険 (/etc/environment は PAM 経由のみで不十分)
+cat > /etc/profile.d/fleetflow-path.sh << 'PROFILE_PATH'
+# FLEETFLOW: login shell PATH (auto-managed, do not edit)
+[ -x /usr/local/bin/mise ] && eval "$(/usr/local/bin/mise activate bash)"
+PROFILE_PATH
+chmod 644 /etc/profile.d/fleetflow-path.sh
+
 echo "✅ mise インストール完了"
-"#;
+"##;
 
 /// Docker installer script
 /// Installs Docker and Docker Compose

--- a/crates/fleetflow-cloud-sakura/src/startup_scripts.rs
+++ b/crates/fleetflow-cloud-sakura/src/startup_scripts.rs
@@ -25,11 +25,26 @@ echo "=== FleetFlow: mise セットアップ ==="
 write_noninteractive_path() {
     local target="$1"
     [ -f "$target" ] || return 0
+    # CWE-59 (symlink-following): user-controlled home 配下 target が symlink だと
+    # root の write が任意 file に到達する。 symlink は明示拒否。
+    if [ -L "$target" ]; then
+        echo "  skip: $target is a symlink (refusing to follow)" >&2
+        return 0
+    fi
     local begin="# FLEETFLOW: non-interactive PATH (auto-managed, do not edit)"
     local end="# FLEETFLOW: end non-interactive PATH"
     if grep -qF "$begin" "$target"; then
         return 0
     fi
+    # 元 ownership / mode を保全 (= /home/<user>/.bashrc を root 所有化しない)
+    local owner_uid owner_gid mode
+    owner_uid=$(stat -c '%u' "$target")
+    owner_gid=$(stat -c '%g' "$target")
+    mode=$(stat -c '%a' "$target")
+    # stage は root-only directory (= /root, mode 700)。 unprivileged user が
+    # 干渉できる場所 (user home / /tmp) には作らない。
+    local tmp
+    tmp=$(mktemp -p /root fleetflow-bashrc.XXXXXX) || return 1
     local block="${begin}
 if [ -x /usr/local/bin/mise ]; then
   eval \"\$(/usr/local/bin/mise activate bash)\"
@@ -42,10 +57,13 @@ ${end}
         awk -v block="$block" '
           !done && /^case \$- in/ { printf "%s", block; done=1 }
           { print }
-        ' "$target" > "${target}.tmp" && mv "${target}.tmp" "$target"
+        ' "$target" > "$tmp"
     else
-        { printf '%s\n' "$block"; cat "$target"; } > "${target}.tmp" && mv "${target}.tmp" "$target"
+        { printf '%s\n' "$block"; cat "$target"; } > "$tmp"
     fi
+    # install -m/-o/-g で mode + owner + group を atomic に復元
+    install -m "$mode" -o "$owner_uid" -g "$owner_gid" "$tmp" "$target"
+    rm -f "$tmp"
 }
 
 # Install mise
@@ -65,11 +83,16 @@ write_noninteractive_path /root/.bashrc
 [ -d /home/ubuntu ] && write_noninteractive_path /home/ubuntu/.bashrc
 
 # login shell 経路の二重保険 (/etc/environment は PAM 経由のみで不十分)
-cat > /etc/profile.d/fleetflow-path.sh << 'PROFILE_PATH'
+PROFILE_TARGET=/etc/profile.d/fleetflow-path.sh
+if [ -L "$PROFILE_TARGET" ]; then
+    echo "  warning: $PROFILE_TARGET is a symlink, refusing to overwrite" >&2
+else
+    cat > "$PROFILE_TARGET" << 'PROFILE_PATH'
 # FLEETFLOW: login shell PATH (auto-managed, do not edit)
 [ -x /usr/local/bin/mise ] && eval "$(/usr/local/bin/mise activate bash)"
 PROFILE_PATH
-chmod 644 /etc/profile.d/fleetflow-path.sh
+    chmod 644 "$PROFILE_TARGET"
+fi
 
 echo "✅ mise インストール完了"
 "##;

--- a/scripts/provision-worker-base.sh
+++ b/scripts/provision-worker-base.sh
@@ -19,12 +19,61 @@
 
 set -euo pipefail
 
-PROVISION_VERSION="v4"
+PROVISION_VERSION="v5"
 
 echo "=== FleetFlow Worker Base Image Provisioning (${PROVISION_VERSION}) ==="
 echo "  Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 echo "  OS:   $(cat /etc/os-release | grep PRETTY_NAME | cut -d= -f2)"
 echo ""
+
+# ─────────────────────────────────────────
+# 共通: 非対話 ssh / login shell で PATH を通すブロックを idempotent 挿入
+# ─────────────────────────────────────────
+# Debian/Ubuntu の .bashrc は冒頭に「非対話なら return」 ガード
+# (`case $- in *i*) ;; *) return;; esac`) を持つ。 brew/mise 公式 install は
+# bashrc 末尾に eval を append するが、 末尾は return ガードより後ろなので
+# `ssh host 'cmd'` (= 非対話・非ログイン) では実行されない = PATH が通らない。
+# /etc/environment も PAM 経由でしか読まれないため非対話 ssh では無効。
+# 解: return ガードの **直前** に marker 付きブロックを idempotent 挿入する。
+write_noninteractive_path() {
+  local target="$1"
+  [ -f "$target" ] || return 0
+  local begin="# FLEETFLOW: non-interactive PATH (auto-managed, do not edit)"
+  local end="# FLEETFLOW: end non-interactive PATH"
+  if grep -qF "$begin" "$target"; then
+    return 0
+  fi
+  local block="${begin}
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"
+fi
+if [ -x /usr/local/bin/mise ]; then
+  eval \"\$(/usr/local/bin/mise activate bash)\"
+elif [ -x \"\$HOME/.local/bin/mise\" ]; then
+  eval \"\$(\$HOME/.local/bin/mise activate bash)\"
+fi
+${end}
+"
+  if grep -q '^case \$- in' "$target"; then
+    awk -v block="$block" '
+      !done && /^case \$- in/ { printf "%s", block; done=1 }
+      { print }
+    ' "$target" > "${target}.tmp" && mv "${target}.tmp" "$target"
+  else
+    { printf '%s\n' "$block"; cat "$target"; } > "${target}.tmp" && mv "${target}.tmp" "$target"
+  fi
+}
+
+# login shell 経路 (/etc/profile.d/*.sh は login shell で必ず source される)
+write_login_path() {
+  cat > /etc/profile.d/fleetflow-path.sh << 'PROFILE_PATH'
+# FLEETFLOW: login shell PATH (auto-managed, do not edit)
+# /etc/environment は PAM 経由のみ。 login shell 用に別途配置して二重に保険。
+[ -x /home/linuxbrew/.linuxbrew/bin/brew ] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+[ -x /usr/local/bin/mise ] && eval "$(/usr/local/bin/mise activate bash)"
+PROFILE_PATH
+  chmod 644 /etc/profile.d/fleetflow-path.sh
+}
 
 # ─────────────────────────────────────────
 # 1. 基本パッケージ
@@ -84,13 +133,11 @@ else
   if [ -f /root/.local/bin/mise ] && [ ! -f /usr/local/bin/mise ]; then
     ln -s /root/.local/bin/mise /usr/local/bin/mise
   fi
-  # bashrc に activate 追加
-  grep -q 'mise activate' /etc/skel/.bashrc 2>/dev/null || \
-    echo 'eval "$(mise activate bash)"' >> /etc/skel/.bashrc
-  grep -q 'mise activate' /root/.bashrc 2>/dev/null || \
-    echo 'eval "$(mise activate bash)"' >> /root/.bashrc
   echo "  installed: $(mise --version 2>/dev/null || echo 'done')"
 fi
+# /etc/skel を先に更新 (= 直後の linuxbrew useradd で skel が cp される前に)
+write_noninteractive_path /etc/skel/.bashrc
+write_noninteractive_path /root/.bashrc
 
 # ─────────────────────────────────────────
 # 5. Homebrew (Linuxbrew)
@@ -106,17 +153,20 @@ else
   fi
   # non-interactive インストール
   NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" > /dev/null 2>&1 || true
-  # パスを通す
   if [ -f /home/linuxbrew/.linuxbrew/bin/brew ]; then
-    grep -q 'linuxbrew' /etc/environment 2>/dev/null || \
-      echo 'PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"' >> /etc/environment
-    grep -q 'linuxbrew' /root/.bashrc 2>/dev/null || \
-      echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /root/.bashrc
     echo "  installed: $(/home/linuxbrew/.linuxbrew/bin/brew --version | head -1)"
   else
     echo "  warning: Homebrew インストールに失敗（続行）"
   fi
 fi
+# PATH 配線 (= mise + brew、 非対話 ssh / login shell 両経路で素のワンライナーが通る状態)
+# /etc/skel + 既存全ユーザーに idempotent 注入。 /etc/environment への append は
+# 非対話 ssh で読まれず誤誘導の元なので v5 から廃止 (= 二重保険は profile.d 側で取る)。
+write_noninteractive_path /etc/skel/.bashrc
+write_noninteractive_path /root/.bashrc
+write_noninteractive_path /home/linuxbrew/.bashrc
+[ -d /home/ubuntu ] && write_noninteractive_path /home/ubuntu/.bashrc
+write_login_path
 
 # ─────────────────────────────────────────
 # 6. Firewall (ufw)

--- a/scripts/provision-worker-base.sh
+++ b/scripts/provision-worker-base.sh
@@ -38,11 +38,26 @@ echo ""
 write_noninteractive_path() {
   local target="$1"
   [ -f "$target" ] || return 0
+  # CWE-59 (symlink-following): user-controlled home 配下 target が symlink だと
+  # root の write が任意 file に到達する。 symlink は明示拒否。
+  if [ -L "$target" ]; then
+    echo "  skip: $target is a symlink (refusing to follow)" >&2
+    return 0
+  fi
   local begin="# FLEETFLOW: non-interactive PATH (auto-managed, do not edit)"
   local end="# FLEETFLOW: end non-interactive PATH"
   if grep -qF "$begin" "$target"; then
     return 0
   fi
+  # 元 ownership / mode を保全 (= /home/<user>/.bashrc を root 所有化しない)
+  local owner_uid owner_gid mode
+  owner_uid=$(stat -c '%u' "$target")
+  owner_gid=$(stat -c '%g' "$target")
+  mode=$(stat -c '%a' "$target")
+  # stage は root-only directory (= /root, mode 700)。 unprivileged user が
+  # 干渉できる場所 (user home / /tmp) には作らない。
+  local tmp
+  tmp=$(mktemp -p /root fleetflow-bashrc.XXXXXX) || return 1
   local block="${begin}
 if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
   eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"
@@ -58,21 +73,30 @@ ${end}
     awk -v block="$block" '
       !done && /^case \$- in/ { printf "%s", block; done=1 }
       { print }
-    ' "$target" > "${target}.tmp" && mv "${target}.tmp" "$target"
+    ' "$target" > "$tmp"
   else
-    { printf '%s\n' "$block"; cat "$target"; } > "${target}.tmp" && mv "${target}.tmp" "$target"
+    { printf '%s\n' "$block"; cat "$target"; } > "$tmp"
   fi
+  # install -m/-o/-g で mode + owner + group を atomic に復元
+  install -m "$mode" -o "$owner_uid" -g "$owner_gid" "$tmp" "$target"
+  rm -f "$tmp"
 }
 
 # login shell 経路 (/etc/profile.d/*.sh は login shell で必ず source される)
 write_login_path() {
-  cat > /etc/profile.d/fleetflow-path.sh << 'PROFILE_PATH'
+  local target=/etc/profile.d/fleetflow-path.sh
+  # /etc 配下なので攻撃 path は狭いが、 一貫性のため symlink check は入れる
+  if [ -L "$target" ]; then
+    echo "  warning: $target is a symlink, refusing to overwrite" >&2
+    return 1
+  fi
+  cat > "$target" << 'PROFILE_PATH'
 # FLEETFLOW: login shell PATH (auto-managed, do not edit)
 # /etc/environment は PAM 経由のみ。 login shell 用に別途配置して二重に保険。
 [ -x /home/linuxbrew/.linuxbrew/bin/brew ] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 [ -x /usr/local/bin/mise ] && eval "$(/usr/local/bin/mise activate bash)"
 PROFILE_PATH
-  chmod 644 /etc/profile.d/fleetflow-path.sh
+  chmod 644 "$target"
 }
 
 # ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Debian/Ubuntu の `.bashrc` の return ガード (`case $- in *i*) ;; *) return;; esac`) より **前** に PATH ブロックを idempotent 挿入し、 非対話 ssh (`ssh host 'cmd'`) で podman/mise が素のワンライナーで見つかる状態を恒久化
- `provision-worker-base.sh` v5: ヘルパ `write_noninteractive_path` / `write_login_path` 追加、 mise/brew step の bashrc 末尾 append を置換
- `cloud-sakura` MISE_SETUP も同思想 (cloud-init には brew が無いので mise のみブロック)、 raw string delimiter を `r##"..."##` に拡張

## Background
creo-memories 本番 deploy 中、 fleet-worker-01 で `ssh linuxbrew@fleet-worker-01 'podman pull ...'` が `podman: command not found` で fail。 fleet-worker-01 自体は手動 hotfix (`.bashrc.bak.*` 退避済) で暫定運用中。 本 PR はサーバ増設時も最初から PATH が通る恒久化。

handoff source: creo-memories `mem_1Cbbv8DeWJ3aT644ooYRDZ`

## 根本原因 (実機検証済)
1. `/etc/environment` は非対話 ssh で読まれない (PAM ログインセッション経由のみ)
2. `.bashrc` 冒頭の `case $- in *i*) ;; *) return;; esac` が brew/mise の eval (末尾 append) より手前で抜ける
3. `XDG_RUNTIME_DIR` は実は不要 (`Linger=yes` で `/run/user/1000` 常駐) — 問題は **PATH 一点**

## Changes
### `scripts/provision-worker-base.sh`
- `PROVISION_VERSION` v4 → v5
- `write_noninteractive_path` / `write_login_path` ヘルパ追加
- mise step ([4/9]) の bashrc 末尾 append を helper 呼び出しに置換
- linuxbrew step ([5/9]) の `/etc/environment` への PATH 注入を廃止、 helper 呼び出しに置換
- 注入先: `/etc/skel/.bashrc` + `/root/.bashrc` + `/home/linuxbrew/.bashrc` + `/home/ubuntu/.bashrc` (存在すれば)
- login shell 経路: `/etc/profile.d/fleetflow-path.sh` を併置
- 順序規律: skel 更新は linuxbrew useradd の **前** に終わるよう mise step 内で先行実行

### `crates/fleetflow-cloud-sakura/src/startup_scripts.rs`
- MISE_SETUP に `write_noninteractive_path` helper を inline で展開 (mise のみブロック)
- cloud-init 用 `/etc/profile.d/fleetflow-path.sh` 配置
- raw string delimiter `r#"..."#` → `r##"..."##` (bash 内 `"# FLEETFLOW: ..."` との衝突回避)

## Test plan
- [x] `bash -n scripts/provision-worker-base.sh` syntax clean
- [x] `cargo test -p fleetflow-cloud-sakura --lib startup_scripts` — 9 passed
- [ ] 実機: 新規 worker 作成時 `ssh <host> 'command -v podman; command -v mise'` が素でフルパスを返す
- [ ] 実機: `ssh <host> 'systemctl --user is-active <svc>'` が active

## 既存 fleet-worker-01 の手動 hotfix について
fleet-worker-01 の `.bashrc` には先行投入された手動 hotfix:
```bash
# CREO-DEPLOY: non-interactive brew PATH
if [ -x ~/.linuxbrew/bin/brew ]; then eval "$(~/.linuxbrew/bin/brew shellenv)"; fi
```
が残る。 v5 の marker (`# FLEETFLOW:`) とは別物なので衝突しないが、 動作が二重になる (= 害は無いが冗長)。 PR merge 後、 fleet-worker-01 で `.bashrc` の `# CREO-DEPLOY:` 行を手で消すか、 次回再 provisioning 時に手で整理する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)